### PR TITLE
Compatibility with PS5 env

### DIFF
--- a/bin/openstack-run
+++ b/bin/openstack-run
@@ -19,7 +19,7 @@ test_name="$(basename "${script}")"
 shift 3
 
 KEY_NAME="ssh-key"
-FLAVOR="staging-cpu8-ram32-disk20"
+FLAVOR="$(openstack flavor list -f value -c Name | grep -m1 'cpu8-ram32-disk20\b')"
 NETWORK="$(openstack network list -f value -c Name | grep -Fm1 "net_stg-lxd-cloud-testing")"
 IMAGE="$(openstack image list -f value -c Name --sort-column Name --sort-descending | grep -Fm1 "auto-sync/ubuntu-${serie}")"
 NAME="lxd-ci-${test_name}-${serie}-$$"

--- a/bin/openstack-run
+++ b/bin/openstack-run
@@ -20,7 +20,7 @@ shift 3
 
 KEY_NAME="ssh-key"
 FLAVOR="staging-cpu8-ram32-disk20"
-NETWORK="net_stg-lxd-cloud-testing"
+NETWORK="$(openstack network list -f value -c Name | grep -Fm1 "net_stg-lxd-cloud-testing")"
 IMAGE="$(openstack image list -f value -c Name --sort-column Name --sort-descending | grep -Fm1 "auto-sync/ubuntu-${serie}")"
 NAME="lxd-ci-${test_name}-${serie}-$$"
 

--- a/bin/openstack-run
+++ b/bin/openstack-run
@@ -21,7 +21,7 @@ shift 3
 KEY_NAME="ssh-key"
 FLAVOR="staging-cpu8-ram32-disk20"
 NETWORK="net_stg-lxd-cloud-testing"
-IMAGE="$(openstack image list -f csv --quote minimal -c Name --sort-column Name --sort-descending | grep -Fm1 "auto-sync/ubuntu-${serie}")"
+IMAGE="$(openstack image list -f value -c Name --sort-column Name --sort-descending | grep -Fm1 "auto-sync/ubuntu-${serie}")"
 NAME="lxd-ci-${test_name}-${serie}-$$"
 
 if ! [ -e ~/.ssh/id_ed25519 ]; then


### PR DESCRIPTION
On PS5, the flavors, networks are named differently so look them up. I couldn't do a full test run because on PS5, the bastion isn't automatically allowed to reach the VMs. The missing firewall change for that bit is on its way though.