### PR TITLE
tests/*: stop purging old debs and keep cloud-init

### DIFF
--- a/tests/cpu-vm
+++ b/tests/cpu-vm
@@ -39,10 +39,6 @@ trap cleanup EXIT HUP INT TERM
 waitSnapdSeed
 
 # Install LXD
-while [ -e /usr/bin/lxd ]; do
-    apt-get remove --purge --yes lxd lxd-client lxcfs liblxc1
-done
-apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
 lxd waitready --timeout=300

--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -33,10 +33,6 @@ trap cleanup EXIT HUP INT TERM
 waitSnapdSeed
 
 # Install LXD
-while [ -e /usr/bin/lxd ]; do
-    apt-get remove --purge --yes lxd lxd-client lxcfs liblxc1
-done
-apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
 apt-get install --no-install-recommends --yes jq

--- a/tests/docker
+++ b/tests/docker
@@ -33,10 +33,6 @@ trap cleanup EXIT HUP INT TERM
 waitSnapdSeed
 
 # Install LXD
-while [ -e /usr/bin/lxd ]; do
-    apt-get remove --purge --yes lxd lxd-client lxcfs liblxc1
-done
-apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
 apt-get install --no-install-recommends --yes jq

--- a/tests/network
+++ b/tests/network
@@ -52,10 +52,6 @@ trap cleanup EXIT HUP INT TERM
 waitSnapdSeed
 
 # Install LXD
-while [ -e /usr/bin/lxd ]; do
-    apt-get remove --purge --yes lxd lxd-client lxcfs liblxc1
-done
-apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
 apt-get install --no-install-recommends --yes jq

--- a/tests/network-routed
+++ b/tests/network-routed
@@ -33,10 +33,6 @@ trap cleanup EXIT HUP INT TERM
 waitSnapdSeed
 
 # Install LXD
-while [ -e /usr/bin/lxd ]; do
-    apt-get remove --purge --yes lxd lxd-client lxcfs liblxc1
-done
-apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
 lxd waitready --timeout=300

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -113,10 +113,6 @@ trap cleanup EXIT HUP INT TERM
 waitSnapdSeed
 
 # Install LXD
-while [ -e /usr/bin/lxd ]; do
-    apt-get remove --purge --yes lxd lxd-client lxcfs liblxc1
-done
-apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
 apt-get install --no-install-recommends --yes jq

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -35,10 +35,6 @@ trap cleanup EXIT HUP INT TERM
 waitSnapdSeed
 
 # Install LXD
-while [ -e /usr/bin/lxd ]; do
-    apt-get remove --purge --yes lxd lxd-client lxcfs liblxc1
-done
-apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
 lxd waitready --timeout=300

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -34,10 +34,6 @@ trap cleanup EXIT HUP INT TERM
 waitSnapdSeed
 
 # Install LXD
-while [ -e /usr/bin/lxd ]; do
-    apt-get remove --purge --yes lxd lxd-client lxcfs liblxc1
-done
-apt-get remove --purge cloud-init --yes
 snap remove lxd || true
 snap install lxd --channel=latest/edge
 apt-get install --no-install-recommends --yes jq

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -34,10 +34,6 @@ trap cleanup EXIT HUP INT TERM
 waitSnapdSeed
 
 # Install LXD
-while [ -e /usr/bin/lxd ]; do
-    apt-get remove --purge --yes lxd lxd-client lxcfs liblxc1
-done
-apt-get remove --purge cloud-init --yes
 apt-get install --no-install-recommends --yes genisoimage
 snap remove lxd || true
 snap install lxd --channel=latest/edge


### PR DESCRIPTION
The old debs are no longer installed on Focal+ so
there is no need to try to remove them.

cloud-init causes no harm and can be used in some env.