### PR TITLE
Add `gpu-container` test

### DIFF
--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -60,21 +60,15 @@ echo "==> Testing with one GPU"
 lxc config device add c1 gpu0 gpu id=0
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 
-# Validate with two GPus
-echo "==> Testing with two GPUs"
-lxc config device add c1 gpu1 gpu id=1
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "2" ] || false
-
 # Validate with all remove
 echo "==> Testing with no GPU"
 lxc config device remove c1 gpu0
-lxc config device remove c1 gpu1
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "0" ] || false
 
 # Validate with all GPUs
 echo "==> Testing with all GPUs"
 lxc config device add c1 gpus gpu
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "3" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 
 # Test nvidia runtime
 echo "==> Testing nvidia runtime"
@@ -88,16 +82,14 @@ lxc exec c1 -- nvidia-smi
 echo "==> Testing PCI address selection"
 lxc config device remove c1 gpus
 lxc config device add c1 gpu1 gpu pci=0000:06:00.0
-lxc config device add c1 gpu2 gpu pci=0000:07:00.0
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "2" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 lxc exec c1 -- nvidia-smi
 
 # Test with vendor
 echo "==> Testing PCI vendor selection"
 lxc config device remove c1 gpu1
-lxc config device remove c1 gpu2
 lxc config device add c1 gpus gpu vendorid=10de
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "2" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 lxc exec c1 -- nvidia-smi
 
 # Test with vendor and product

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -29,6 +29,25 @@ cleanup() {
 FAIL=1
 trap cleanup EXIT HUP INT TERM
 
+# Install required components from "restricted" pocket
+if ! grep -v '^#' /etc/apt/sources.list | grep -qwFm1 restricted; then
+    ARCH="$(dpkg --print-architecture)"
+    DISTRO="$(lsb_release -sc)"
+    if [ "$ARCH" != "amd64" ]; then
+        cat << EOF > /etc/apt/sources.list.d/restricted.list
+deb [arch=${ARCH}] http://ports.ubuntu.com/ubuntu-ports ${DISTRO} restricted
+deb [arch=${ARCH}] http://ports.ubuntu.com/ubuntu-ports ${DISTRO}-updates restricted
+EOF
+    else
+        cat << EOF > /etc/apt/sources.list.d/restricted.list
+deb [arch=${ARCH}] http://archive.ubuntu.com/ubuntu/ ${DISTRO} restricted
+deb [arch=${ARCH}] http://archive.ubuntu.com/ubuntu/ ${DISTRO}-updates restricted
+EOF
+    fi
+    apt-get update
+fi
+apt-get install --yes nvidia-utils-525 nvidia-driver-525
+
 # Wait for snapd seeding
 waitSnapdSeed
 

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -97,5 +97,6 @@ echo "==> Testing PCI vendor and product selection"
 lxc config device remove c1 gpus
 lxc config device add c1 gpus gpu vendorid=10de productid=27b8
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
+lxc exec c1 -- nvidia-smi
 
 FAIL=0

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -1,0 +1,109 @@
+#!/bin/sh
+set -eu
+
+waitSnapdSeed() (
+  set +x
+  for i in $(seq 60); do # Wait up to 60s.
+    if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
+      return 0 # Success.
+    fi
+
+    sleep 1
+  done
+
+  echo "snapd not seeded after ${i}s"
+  return 1 # Failed.
+)
+
+cleanup() {
+    echo ""
+    if [ "${FAIL}" = "1" ]; then
+        echo "Test failed"
+        exit 1
+    fi
+
+    echo "Test passed"
+    exit 0
+}
+
+FAIL=1
+trap cleanup EXIT HUP INT TERM
+
+# Wait for snapd seeding
+waitSnapdSeed
+
+# Install LXD
+snap remove lxd || true
+snap install lxd --channel=latest/edge
+lxd waitready --timeout=300
+
+# Check that NVIDIA is installed
+nvidia-smi
+
+# Configure LXD
+lxc storage create default zfs
+lxc profile device add default root disk path=/ pool=default
+lxc network create lxdbr0
+lxc profile device add default eth0 nic network=lxdbr0 name=eth0
+
+# Launch a test container
+echo "==> Launching a test container"
+lxc launch ubuntu:20.04 c1
+sleep 10
+
+# Confirm no GPU
+echo "==> Testing with no GPU"
+! lxc exec c1 -- ls -lh /dev/dri/ || false
+
+# Validate with one GPU
+echo "==> Testing with one GPU"
+lxc config device add c1 gpu0 gpu id=0
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "1" ] || false
+
+# Validate with two GPus
+echo "==> Testing with two GPUs"
+lxc config device add c1 gpu1 gpu id=1
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "2" ] || false
+
+# Validate with all remove
+echo "==> Testing with no GPU"
+lxc config device remove c1 gpu0
+lxc config device remove c1 gpu1
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "0" ] || false
+
+# Validate with all GPUs
+echo "==> Testing with all GPUs"
+lxc config device add c1 gpus gpu
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "3" ] || false
+
+# Test nvidia runtime
+echo "==> Testing nvidia runtime"
+! lxc exec c1 -- nvidia-smi || false
+lxc stop c1
+lxc config set c1 nvidia.runtime true
+lxc start c1
+lxc exec c1 -- nvidia-smi
+
+# Test with PCI addresses
+echo "==> Testing PCI address selection"
+lxc config device remove c1 gpus
+lxc config device add c1 gpu1 gpu pci=0000:06:00.0
+lxc config device add c1 gpu2 gpu pci=0000:07:00.0
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "2" ] || false
+lxc exec c1 -- nvidia-smi
+
+# Test with vendor
+echo "==> Testing PCI vendor selection"
+lxc config device remove c1 gpu1
+lxc config device remove c1 gpu2
+lxc config device add c1 gpus gpu vendorid=10de
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "2" ] || false
+lxc exec c1 -- nvidia-smi
+
+# Test with vendor and product
+echo "==> Testing PCI vendor and product selection"
+lxc config device remove c1 gpus
+lxc config device add c1 gpus gpu vendorid=1af4 productid=0010
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "1" ] || false
+
+FAIL=0

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -58,23 +58,23 @@ echo "==> Testing with no GPU"
 # Validate with one GPU
 echo "==> Testing with one GPU"
 lxc config device add c1 gpu0 gpu id=0
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "1" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 
 # Validate with two GPus
 echo "==> Testing with two GPUs"
 lxc config device add c1 gpu1 gpu id=1
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "2" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "2" ] || false
 
 # Validate with all remove
 echo "==> Testing with no GPU"
 lxc config device remove c1 gpu0
 lxc config device remove c1 gpu1
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "0" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "0" ] || false
 
 # Validate with all GPUs
 echo "==> Testing with all GPUs"
 lxc config device add c1 gpus gpu
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "3" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "3" ] || false
 
 # Test nvidia runtime
 echo "==> Testing nvidia runtime"
@@ -89,7 +89,7 @@ echo "==> Testing PCI address selection"
 lxc config device remove c1 gpus
 lxc config device add c1 gpu1 gpu pci=0000:06:00.0
 lxc config device add c1 gpu2 gpu pci=0000:07:00.0
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "2" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "2" ] || false
 lxc exec c1 -- nvidia-smi
 
 # Test with vendor
@@ -97,13 +97,13 @@ echo "==> Testing PCI vendor selection"
 lxc config device remove c1 gpu1
 lxc config device remove c1 gpu2
 lxc config device add c1 gpus gpu vendorid=10de
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "2" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "2" ] || false
 lxc exec c1 -- nvidia-smi
 
 # Test with vendor and product
 echo "==> Testing PCI vendor and product selection"
 lxc config device remove c1 gpus
 lxc config device add c1 gpus gpu vendorid=1af4 productid=0010
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c card)" = "1" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 
 FAIL=0

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -95,7 +95,7 @@ lxc exec c1 -- nvidia-smi
 # Test with vendor and product
 echo "==> Testing PCI vendor and product selection"
 lxc config device remove c1 gpus
-lxc config device add c1 gpus gpu vendorid=1af4 productid=0010
+lxc config device add c1 gpus gpu vendorid=10de productid=27b8
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 
 FAIL=0


### PR DESCRIPTION
The old script was testing with 3 different GPUs but the test system I was provided only had 1 so I adapted the script accordingly.

@morphis if you want to test with multiple GPUs, please let me know. I picked the `525` drivers but should I use the `535` instead? Does it matter? What about the `-server` utils?