### PR TITLE
Update `test/kernel` script

### DIFF
--- a/bin/openstack-run
+++ b/bin/openstack-run
@@ -44,6 +44,7 @@ create() {
     echo "==> Creating a machine" >&2
     openstack server create --key-name "${KEY_NAME}" --flavor "${FLAVOR}" --network "${NETWORK}" --image "${IMAGE}" --user-data ./cloud-init.user-data.yaml --wait "${NAME}"
     IP="$(openstack server show -f value -c addresses "${NAME}" | cut -d\' -f4)"
+    [ "${IP}" != "{}" ]
     echo "${NAME}: ${IP}" >&2
 }
 

--- a/tests/kernel
+++ b/tests/kernel
@@ -44,9 +44,9 @@ export PATH="${PATH}:/root/go/bin"
 
 # Build LXD
 cd /root
-mkdir -p /root/go/src/github.com/lxc
-git clone https://github.com/lxc/lxd /root/go/src/github.com/lxc/lxd
-cd /root/go/src/github.com/lxc/lxd
+mkdir -p /root/go/src/github.com/canonical
+git clone https://github.com/canonical/lxd /root/go/src/github.com/canonical/lxd
+cd /root/go/src/github.com/canonical/lxd
 make deps
 make
 
@@ -72,7 +72,7 @@ if [ -e "/sys/fs/cgroup/cgroup.procs" ]; then
 fi
 
 # Run tests
-cd /root/go/src/github.com/lxc/lxd/test
+cd /root/go/src/github.com/canonical/lxd/test
 uname -a
 
 # LXD_SHIFTFS_DISABLE=1 because of kernel regression https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1990849


### PR DESCRIPTION
This test requires access to https://launchpad.net/~ubuntu-lxc/+archive/ubuntu/daily which isn't (yet) accessible from PS5/6 so I couldn't test it.

Once we have proxy access, I'll look into adding it to `test/main.sh` list.