### PR TITLE
Add NVMe test to `tests/storage-disks-vm`

### DIFF
--- a/bin/openstack-run
+++ b/bin/openstack-run
@@ -37,6 +37,13 @@ wait_machine() {
         nc -w1 -z "${IP}" 22 && break
         sleep 1
     done
+
+    # Work around regression in cloud-init delaying SSH access
+    # https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2039441
+    for _ in $(seq 30); do
+        ssh -o ConnectTimeout=1 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "ubuntu@${IP}" true && break
+	sleep 1
+    done
 }
 
 create() {

--- a/bin/openstack-run
+++ b/bin/openstack-run
@@ -21,7 +21,7 @@ shift 3
 KEY_NAME="ssh-key"
 FLAVOR="$(openstack flavor list -f value -c Name | grep -m1 'cpu8-ram32-disk20\b')"
 NETWORK="$(openstack network list -f value -c Name | grep -Fm1 "net_stg-lxd-cloud-testing")"
-IMAGE="$(openstack image list -f value -c Name --sort-column Name --sort-descending | grep -Fm1 "auto-sync/ubuntu-${serie}")"
+IMAGE="$(openstack image list -f value -c Name --sort-column Name --sort-descending | grep -m1 "auto-sync/ubuntu-${serie}-.*-amd64-")"
 NAME="lxd-ci-${test_name}-${serie}-$$"
 
 if ! [ -e ~/.ssh/id_ed25519 ]; then

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -15,3 +15,6 @@
 ./bin/openstack-run jammy default tests/pylxd latest/edge
 ./bin/openstack-run jammy default tests/pylxd 5.0/edge
 ./bin/openstack-run jammy default tests/pylxd 4.0/edge
+
+# storage
+./bin/openstack-run jammy default tests/storage-disks-vm

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -107,11 +107,11 @@ lxc config device add v1 d1 disk source="${testRoot}/allowed1/not-allowed1" path
 lxc config device set v1 d1 source="${testRoot}/allowed1" shift=true
 ! lxc start v1 || false
 
-# Check adding a disk with a source path that is allowed is allowed.
+# Check adding a disk with a source path that is allowed.
 lxc config device set v1 d1 source="${testRoot}/allowed1" shift=false
 lxc start v1
 waitVMAgent v1
-lxc exec v1 --project restricted -- ls -l /mnt/foo1
+lxc exec v1 -- ls -l /mnt/foo1
 lxc stop -f v1
 
 # Check adding a disk with a source path that is allowed that symlinks to another allowed source path isn't
@@ -123,7 +123,7 @@ lxc config device set v1 d1 source="${testRoot}/allowed1/not-allowed2"
 lxc config device set v1 d1 source="${testRoot}/allowed1/foolink" path=/mnt/foolink
 lxc start v1
 waitVMAgent v1
-[ "$(lxc exec v1 --project restricted  -- stat /mnt/foolink -c '%u:%g')" = "65534:65534" ] || false
+[ "$(lxc exec v1  -- stat /mnt/foolink -c '%u:%g')" = "65534:65534" ] || false
 lxc stop -f v1
 
 # Check usage of raw.idmap is restricted.
@@ -147,8 +147,8 @@ lxc config set v1 raw.idmap="both 1000 1000"
 lxc config device set v1 d1 source="${testRoot}/allowed1" path=/mnt
 lxc start v1 || (lxc info --show-log c1 ; false)
 waitVMAgent v1
-[ "$(lxc exec v1 --project restricted  -- stat /mnt/foo1 -c '%u:%g')" = "1000:1000" ] || false
-[ "$(lxc exec v1 --project restricted  -- stat /mnt/foo2 -c '%u:%g')" = "65534:65534" ] || false
+[ "$(lxc exec v1  -- stat /mnt/foo1 -c '%u:%g')" = "1000:1000" ] || false
+[ "$(lxc exec v1  -- stat /mnt/foo2 -c '%u:%g')" = "65534:65534" ] || false
 
 # Check security.secureboot setting is applied to running VM at next start up.
 lxc exec v1 -- mokutil --sb-state | grep -Fx "SecureBoot enabled"

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -112,7 +112,7 @@ lxc config device set v1 d1 source="${testRoot}/allowed1" shift=true
 lxc config device set v1 d1 source="${testRoot}/allowed1" shift=false
 lxc start v1
 waitVMAgent v1
-lxc exec v1 --project restricted -- ls /mnt/foo1
+lxc exec v1 --project restricted -- ls -l /mnt/foo1
 lxc stop -f v1
 
 # Check adding a disk with a source path that is allowed that symlinks to another allowed source path isn't

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -82,7 +82,6 @@ lxc project create restricted \
   -c restricted=true \
   -c restricted.devices.disk=allow \
   -c restricted.devices.disk.paths="${testRoot}/allowed1,${testRoot}/allowed2"
-  lxc project switch restricted
 lxc project switch restricted
 lxc profile device add default root disk path="/" pool=default
 lxc profile device add default eth0 nic network=lxdbr0

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -164,6 +164,7 @@ lxc exec v1 -- mokutil --sb-state | grep -Fx "SecureBoot disabled"
 
 # Remove disk device restrictions and add a NVMe disk
 lxc stop -f v1
+lxc config device remove v1 d1
 lxc project unset restricted restricted.devices.disk
 lxc project unset restricted restricted.devices.disk.paths
 lxc project unset restricted restricted

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -91,7 +91,7 @@ lxc profile device add default eth0 nic network=lxdbr0
 lxc profile show default
 
 # Create instance and add check relative source paths are not allowed.
-lxc init images:ubuntu/20.04 v1 --vm
+lxc init ubuntu:20.04 v1 --vm
 ! lxc config device add v1 d1 disk source=foo path=/mnt || false
 
 # Check adding a disk with a source path above the restricted parent source path isn't allowed.

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -71,6 +71,11 @@ ln -s "${testRoot}/not-allowed1" "${testRoot}/allowed1/not-allowed1"
 ln -s "${testRoot}/allowed2" "${testRoot}/allowed1/not-allowed2"
 (cd "${testRoot}/allowed1" || false; ln -s foo1 foolink)
 
+# Create loop device to use as NVMe disk
+loopimg="$(mktemp)"
+truncate -s 100M "${loopimg}"
+loopdev="$(losetup --show --find "${loopimg}")"
+
 # Configure LXD
 lxc project switch default
 lxc network create lxdbr0
@@ -157,6 +162,18 @@ lxc restart -f v1
 waitVMAgent v1
 lxc exec v1 -- mokutil --sb-state | grep -Fx "SecureBoot disabled"
 
+# Remove disk device restrictions and add a NVMe disk
+lxc stop -f v1
+lxc project unset restricted restricted.devices.disk
+lxc project unset restricted restricted.devices.disk.paths
+lxc project unset restricted restricted
+
+# Add a NVMe disk and check if a NVMe controller is added to the VM
+lxc config device add v1 nvme-ssd disk source="${loopdev}" io.bus=nvme
+lxc start v1
+waitVMAgent v1
+lxc exec v1 -- lspci | grep -F "QEMU NVM Express Controller"
+
 echo "==> Cleanup"
 lxc delete -f v1
 lxc project switch default
@@ -173,5 +190,7 @@ rmdir "${testRoot}/allowed1"
 rmdir "${testRoot}/allowed2"
 rmdir "${testRoot}/not-allowed1"
 rmdir "${testRoot}"
+losetup --detach "${loopdev}"
+rm "${loopimg}"
 
 FAIL=0

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -eux
 
-# This test uses openat2 which requires kernel >= 5.6 (so use Focal HWE).
-
 waitSnapdSeed() (
   set +x
   for i in $(seq 60); do # Wait up to 60s.

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -89,7 +89,7 @@ lxc profile device add default eth0 nic network=lxdbr0
 lxc profile show default
 
 # Create instance and add check relative source paths are not allowed.
-lxc init ubuntu:20.04 v1 --vm
+lxc init ubuntu:22.04 v1 --vm
 ! lxc config device add v1 d1 disk source=foo path=/mnt || false
 
 # Check adding a disk with a source path above the restricted parent source path isn't allowed.


### PR DESCRIPTION
This is the output of the test running on PS6:

```
+ lxc stop -f v1
+ lxc config device remove v1 d1
Device d1 removed from v1
+ lxc project unset restricted restricted.devices.disk
+ lxc project unset restricted restricted.devices.disk.paths
+ lxc project unset restricted restricted
+ lxc config device add v1 nvme-ssd disk source=/dev/loop4 io.bus=nvme
Device nvme-ssd added to v1
+ lxc start v1
+ waitVMAgent v1
+ set +x
+ + grep -F QEMU NVM Express Controller
lxc exec v1 -- lspci
06:00.0 Non-Volatile memory controller: Red Hat, Inc. QEMU NVM Express Controller (rev 02)
==> Cleanup
+ echo ==> Cleanup
+ lxc delete -f v1
+ lxc project switch default
+ lxc project delete restricted
Project restricted deleted
+ lxc storage delete default
Storage pool default deleted
+ lxc network delete lxdbr0
Network lxdbr0 deleted
+ rm /opt/lxd-test-restricted/allowed1/not-allowed1
+ rm /opt/lxd-test-restricted/allowed1/not-allowed2
+ rmdir /opt/lxd-test-restricted/allowed1/foo1
+ rmdir /opt/lxd-test-restricted/allowed1/foo2
+ rm /opt/lxd-test-restricted/allowed1/foolink
+ rmdir /opt/lxd-test-restricted/allowed1
+ rmdir /opt/lxd-test-restricted/allowed2
+ rmdir /opt/lxd-test-restricted/not-allowed1
+ rmdir /opt/lxd-test-restricted
+ losetup --detach /dev/loop4
+ rm /tmp/tmp.H18ffQstwR

Test passed
+ FAIL=0
+ cleanup
+ echo 
+ [ 0 = 1 ]
+ echo Test passed
+ exit 0
+ RET=0
+ cleanup
+ set +e
+ openstack server delete lxd-ci-storage-disks-vm-jammy-1876547
+ [ 0 = 0 ]
+ echo 

+ echo ==> Test passed (storage-disks-vm)
==> Test passed (storage-disks-vm)
+ exit 0
```