### PR TITLE
Local run

### DIFF
--- a/bin/local-run
+++ b/bin/local-run
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ux
+
+script="${1}"
+lxd_snap_channel="${2}"
+shift 2
+_script="$(mktemp)"
+test_name="$(basename "${script}")"
+
+echo "==> Running the job ${test_name} against ${lxd_snap_channel}" >&2
+sed -e "1 a LXD_SNAP_CHANNEL=${lxd_snap_channel}" -e "1 r bin/helpers" "${script}" > "${_script}"
+exec sh "${_script}"

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -1,34 +1,6 @@
 #!/bin/sh
 set -eu
 
-waitSnapdSeed() (
-  set +x
-  for i in $(seq 60); do # Wait up to 60s.
-    if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
-      return 0 # Success.
-    fi
-
-    sleep 1
-  done
-
-  echo "snapd not seeded after ${i}s"
-  return 1 # Failed.
-)
-
-cleanup() {
-    echo ""
-    if [ "${FAIL}" = "1" ]; then
-        echo "Test failed"
-        exit 1
-    fi
-
-    echo "Test passed"
-    exit 0
-}
-
-FAIL=1
-trap cleanup EXIT HUP INT TERM
-
 # Install required components from "restricted" pocket
 if ! grep -v '^#' /etc/apt/sources.list | grep -qwFm1 restricted; then
     ARCH="$(dpkg --print-architecture)"
@@ -48,13 +20,8 @@ EOF
 fi
 apt-get install --yes nvidia-utils-525 nvidia-driver-525
 
-# Wait for snapd seeding
-waitSnapdSeed
-
 # Install LXD
-snap remove lxd || true
-snap install lxd --channel=latest/edge
-lxd waitready --timeout=300
+install_lxd
 
 # Check that NVIDIA is installed
 nvidia-smi
@@ -118,4 +85,5 @@ lxc config device add c1 gpus gpu vendorid=10de productid=27b8
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 lxc exec c1 -- nvidia-smi
 
+# shellcheck disable=SC2034
 FAIL=0

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -16,8 +16,8 @@ deb [arch=${ARCH}] http://archive.ubuntu.com/ubuntu/ ${DISTRO} restricted
 deb [arch=${ARCH}] http://archive.ubuntu.com/ubuntu/ ${DISTRO}-updates restricted
 EOF
     fi
-    apt-get update
 fi
+apt-get update
 apt-get install --yes nvidia-utils-525 nvidia-driver-525
 
 # Install LXD


### PR DESCRIPTION
The helper functions provided by `bin/helpers` allow pooling common setup bits including the LXD snap installation from the desired channel into a single shell script. The `bin/local-run` script can then be used to stitch together the helper functions and the test script to be run, something like:

```
./bin/local-run tests/gpu-container 5.0/edge
```

Instead of directly calling the script and having it testing only `latest/edge`:

```
./tests/gpu-container
```

@morphis this PR would require you to change how that `gpu-container` test is run on your side.
