### PR TITLE
Rework helper functions to wait for instance readiness

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -36,12 +36,12 @@ waitInstanceReady() (
       sleep 1
   done
 
-  echo "Instance ${instName} (${instProj}) agent not running after ${i}s"
+  echo "Instance ${instName} (${instProj}) not ready after ${maxWait}s"
   return 1 # Failed.
 )
 
-# waitInstanceReady: waits for the instance to be ready.
-waitInstanceReady() (
+# waitInstanceBooted: waits for the instance to be ready and fully booted.
+waitInstanceBooted() (
   set +x
   maxWait=90
   instName="$1"
@@ -51,14 +51,8 @@ waitInstanceReady() (
     instProj="$(lxc project list -f csv | sed -n 's/^\([^(]\+\) (current),.*/\1/ p')"
   fi
 
-  # Wait for the instance to report a valid number of processes.
-  processes=0
-  for _ in $(seq "${maxWait}"); do
-      processes="$(lxc info --project "${instProj}" "${instName}" | awk '{if ($1 == "Processes:") print $2}')"
-      if [ "${processes}" -gt 0 ]; then
-          break
-      fi
-  done
+  # Wait for the instance to be ready
+  waitInstanceReady "${instName}" "${instProj}"
 
   # Then wait for the boot sequence to complete.
   state="$(lxc exec --project "${instProj}" "${instName}" -- timeout "${maxWait}" systemctl is-system-running --wait || true)"
@@ -66,7 +60,7 @@ waitInstanceReady() (
     return 0 # Success.
   fi
 
-  echo "Instance ${instName} (${instProj}) not ready after ${maxWait}s"
+  echo "Instance ${instName} (${instProj}) not booted after ${maxWait}s"
   lxc list --project "${instProj}" "${instName}"
   return 1 # Failed.
 )

--- a/bin/helpers
+++ b/bin/helpers
@@ -55,6 +55,7 @@ waitInstanceBooted() (
   waitInstanceReady "${instName}" "${instProj}"
 
   # Then wait for the boot sequence to complete.
+  sleep 1
   state="$(lxc exec --project "${instProj}" "${instName}" -- timeout "${maxWait}" systemctl is-system-running --wait || true)"
   if [ "${state}" = "running" ]; then
     return 0 # Success.

--- a/bin/helpers
+++ b/bin/helpers
@@ -15,25 +15,28 @@ waitSnapdSeed() (
   return 1 # Failed.
 )
 
-# waitVMAgent: waits for the VM agent to be running.
-waitVMAgent() (
+# waitInstanceReady: waits for the instance to be ready (processes count > 1).
+waitInstanceReady() (
   set +x
-  vmName="${1}"
+  maxWait=90
+  instName="${1}"
   instProj="${2:-}"
   if [ -z "${instProj}" ]; then
     # Find the currently selected project.
     instProj="$(lxc project list -f csv | sed -n 's/^\([^(]\+\) (current),.*/\1/ p')"
   fi
 
-  for i in $(seq 90); do
-    if lxc info --project "${instProj}" "${vmName}" | grep -qF 127.0.0.1; then
-      return 0 # Success.
-    fi
-
-    sleep 1
+  # Wait for the instance to report more than one process.
+  processes=0
+  for _ in $(seq "${maxWait}"); do
+      processes="$(lxc info --project "${instProj}" "${instName}" | awk '{if ($1 == "Processes:") print $2}')"
+      if [ "${processes}" -gt 1 ]; then
+          return 0 # Success.
+      fi
+      sleep 1
   done
 
-  echo "VM ${vmName} (${instProj}) agent not running after ${i}s"
+  echo "Instance ${instName} (${instProj}) agent not running after ${i}s"
   return 1 # Failed.
 )
 
@@ -48,11 +51,16 @@ waitInstanceReady() (
     instProj="$(lxc project list -f csv | sed -n 's/^\([^(]\+\) (current),.*/\1/ p')"
   fi
 
-  # For VMs, wait for the agent to be connected before trying to exec into it
-  if lxc info --project "${instProj}" "${instName}" | grep -qxF 'Type: virtual-machine'; then
-      waitVMAgent "${instName}" "${instProj}"
-  fi
+  # Wait for the instance to report a valid number of processes.
+  processes=0
+  for _ in $(seq "${maxWait}"); do
+      processes="$(lxc info --project "${instProj}" "${instName}" | awk '{if ($1 == "Processes:") print $2}')"
+      if [ "${processes}" -gt 0 ]; then
+          break
+      fi
+  done
 
+  # Then wait for the boot sequence to complete.
   state="$(lxc exec --project "${instProj}" "${instName}" -- timeout "${maxWait}" systemctl is-system-running --wait || true)"
   if [ "${state}" = "running" ]; then
     return 0 # Success.

--- a/tests/cgroup
+++ b/tests/cgroup
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -eu
 
+# linux-image-kvm doesn't support setting limits.egress/limits.ingress
+if uname -r | grep -- "-kvm$"; then
+    echo "The -kvm kernel flavor does not have the required extra modules needed by this test."
+    # shellcheck disable=SC2034
+    FAIL=0
+    exit 0
+fi
+
 # Install dependencies
 install_deps jq iperf3
 

--- a/tests/cgroup
+++ b/tests/cgroup
@@ -60,6 +60,8 @@ lxc config set c1 limits.cpu=2-2
 [ "$(lxc exec c1 -- nproc)" = "1" ]
 
 lxc config unset c1 limits.cpu
+# XXX: avoid a race (https://github.com/canonical/lxd/issues/12659)
+sleep 2
 [ "$(lxc exec c1 -- nproc)" = "$(nproc)" ]
 
 lxc config set c1 limits.cpu.priority 5

--- a/tests/cpu-vm
+++ b/tests/cpu-vm
@@ -21,7 +21,7 @@ lxc storage create "${poolName}" "${poolDriver}"
 
 echo "==> Create ephemeral VM and boot"
 lxc launch ubuntu-daily:22.04 v1 --vm -s "${poolName}" --ephemeral
-waitVMAgent v1
+waitInstanceReady v1
 lxc info v1
 
 # Get number of CPUs

--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -19,7 +19,7 @@ lxc storage create "${poolName}" "${poolDriver}"
 
 echo "==> Create VM and boot"
 lxc launch ubuntu-daily:22.04 v1 --vm -s "${poolName}"
-waitVMAgent v1
+waitInstanceReady v1
 lxc info v1
 
 echo "==> Checking devlxd is working"
@@ -33,7 +33,7 @@ lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta
 # Run sync before forcefully restarting the VM otherwise the filesystem will be corrupted.
 lxc exec v1 -- "sync"
 lxc restart -f v1
-waitVMAgent v1
+waitInstanceReady v1
 
 # devlxd should be running after restart
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0 | jq
@@ -50,7 +50,7 @@ echo "==> Checking devlxd is not working"
 
 lxc exec v1 -- "sync"
 lxc restart -f v1
-waitVMAgent v1
+waitInstanceReady v1
 
 # devlxd should not be running after restart
 ! lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0 || false
@@ -81,7 +81,7 @@ sleep 5
 
 # Test nested VM functionality.
 lxc start v1
-waitVMAgent v1
+waitInstanceReady v1
 
 # Configure to use the proxy
 lxc exec v1 -- snap wait system seed.loaded

--- a/tests/network
+++ b/tests/network
@@ -52,12 +52,12 @@ lxc start c1-sriov
 # Wait for VMs to start.
 echo "==> Waiting for VMs to start"
 
-waitInstanceReady c1-physical
-waitInstanceReady c1-macvlan
-waitInstanceReady c1-sriov
-waitInstanceReady v1-physical
-waitInstanceReady v1-macvlan
-waitInstanceReady v1-sriov
+waitInstanceBooted c1-physical
+waitInstanceBooted c1-macvlan
+waitInstanceBooted c1-sriov
+waitInstanceBooted v1-physical
+waitInstanceBooted v1-macvlan
+waitInstanceBooted v1-sriov
 
 # Check that all instances have an IPv4 and IPv6 address
 networkTests() {
@@ -188,7 +188,7 @@ lxc config device set v1-physical eth0 nictype=bridged parent=lxdbr0 network= mt
 lxc start v1-physical
 
 # Wait for lxd-agent to rename the interface.
-waitInstanceReady v1-physical
+waitInstanceBooted v1-physical
 
 # Interface "eth0" should exist in the VM with the correct MTU.
 lxc exec v1-physical -- test -d /sys/class/net/eth0

--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -62,10 +62,10 @@ ovn_basic_tests() {
     lxc start 4u
 
     echo "==> Wait for addresses"
-    waitInstanceReady u1
-    waitInstanceReady u2
-    waitInstanceReady u3
-    waitInstanceReady 4u
+    waitInstanceBooted u1
+    waitInstanceBooted u2
+    waitInstanceBooted u3
+    waitInstanceBooted 4u
     lxc list
 
     echo "==> Testing connectivity"
@@ -123,8 +123,8 @@ ovn_basic_tests() {
     lxc start u2
 
     echo "==> Wait for new addresses"
-    waitInstanceReady u2
-    waitInstanceReady u3
+    waitInstanceBooted u2
+    waitInstanceBooted u3
     lxc list
 
     U2_IPV4="$(lxc list u2 -c4 --format=csv | cut -d' ' -f1)"
@@ -218,7 +218,7 @@ ovn_basic_tests() {
     lxc start u1 --project testovn
 
     # Test external IPs allocated and published using dnat.
-    waitInstanceReady u1 testovn
+    waitInstanceBooted u1 testovn
     U1_EXT_IPV4="$(lxc list u1 --project testovn -c4 --format=csv | cut -d' ' -f1)"
     U1_EXT_IPV6="$(lxc list u1 --project testovn -c6 --format=csv | cut -d' ' -f1)"
     ovn-nbctl --bare --format=csv --column=external_ip,logical_ip,type find nat | grep "${U1_EXT_IPV4},${U1_EXT_IPV4},dnat_and_snat"
@@ -413,8 +413,8 @@ ovn_basic_tests() {
     lxc start u3
 
     echo "==> Wait for addresses"
-    waitInstanceReady u2 testovn
-    waitInstanceReady u3 testovn
+    waitInstanceBooted u2 testovn
+    waitInstanceBooted u3 testovn
     lxc list
 
     echo "==> Testing connectivity"
@@ -529,7 +529,7 @@ ovn_basic_tests() {
 
     # Check connectivity back to uplink bridge without SNAT address specified.
     lxc launch "${instanceImage}" u1 -n ovn-virtual-network -s default
-    waitInstanceReady u1
+    waitInstanceBooted u1
     lxc exec u1 -- ping -nc1 -w5 192.0.2.1
     lxc exec u1 -- ping -nc1 -w5 2001:db8:1:1::1
 
@@ -699,7 +699,7 @@ ovn_forward_tests() {
 
     # Create instance connected to ovn-virtual-network.
     lxc launch "${instanceImage}" u1 -n ovn-virtual-network -s default
-    waitInstanceReady u1
+    waitInstanceBooted u1
     lxc list
     U1_IPV4="$(lxc list u1 -c4 --format=csv | cut -d' ' -f1)"
     U1_IPV6="$(lxc list u1 -c6 --format=csv | cut -d' ' -f1)"
@@ -743,7 +743,7 @@ EOF
 
     # Check TCP port forward of port 53 to a different host.
     lxc launch "${instanceImage}" u2 -n ovn-virtual-network -s default
-    waitInstanceReady u2
+    waitInstanceBooted u2
     lxc list
     U2_IPV4="$(lxc list u2 -c4 --format=csv | cut -d' ' -f1)"
     U2_IPV6="$(lxc list u2 -c6 --format=csv | cut -d' ' -f1)"
@@ -901,7 +901,7 @@ ovn_load_balancer_tests() {
 
     # Create instance connected to ovn-virtual-network.
     lxc launch "${instanceImage}" u1 -n ovn-virtual-network -s default
-    waitInstanceReady u1
+    waitInstanceBooted u1
     lxc list
     U1_IPV4="$(lxc list u1 -c4 --format=csv | cut -d' ' -f1)"
     U1_IPV6="$(lxc list u1 -c6 --format=csv | cut -d' ' -f1)"
@@ -963,7 +963,7 @@ EOF
 
     # Check changing DNS TCP forwarding towards u2.
     lxc launch "${instanceImage}" u2 -n ovn-virtual-network -s default
-    waitInstanceReady u2
+    waitInstanceBooted u2
     lxc list
     U2_IPV4="$(lxc list u2 -c4 --format=csv | cut -d' ' -f1)"
     U2_IPV6="$(lxc list u2 -c6 --format=csv | cut -d' ' -f1)"
@@ -1099,8 +1099,8 @@ ovn_peering_tests() {
         ipv6.routes.external=2001:db8:1:2::2/128
     lxc start ovn1 --project=ovn1
     lxc launch "${instanceImage}" ovn2 -n ovn2 -s default --project=ovn2
-    waitInstanceReady ovn1 ovn1
-    waitInstanceReady ovn2 ovn2
+    waitInstanceBooted ovn1 ovn1
+    waitInstanceBooted ovn2 ovn2
 
     # Add IPs from routes to ovn1 instance.
     lxc exec ovn1 --project=ovn1 -- ip a add 198.51.100.1/32 dev eth0
@@ -1168,7 +1168,7 @@ ovn_peering_tests() {
     ovn-nbctl list address_set | grep -F 2001:db8:1:2::2/128
 
     # Check security policies prevent spoofed packets using peer connection.
-    waitInstanceReady ovn1 ovn1
+    waitInstanceBooted ovn1 ovn1
     ovn1NICIPv4="$(lxc list ovn1 -c4 --format=csv --project=ovn1 | cut -d' ' -f1)"
     ovn1NICIPv6="$(lxc list ovn1 -c6 --format=csv --project=ovn1 | cut -d' ' -f1)"
     ovn2NICIPv4="$(lxc list ovn2 -c4 --format=csv --project=ovn2 | cut -d' ' -f1)"
@@ -1235,7 +1235,7 @@ ovn_peering_tests() {
     lxc delete -f ovn1 --project=ovn1 # Remove as we cleared its DHCP config.
     lxc network set ovn1 ipv4.address=192.0.2.1/24 ipv6.address=2001:db8:1:1::1/64 --project=ovn1
     lxc launch "${instanceImage}" ovn1 -n ovn1 -s default --project=ovn1
-    waitInstanceReady ovn1 ovn1
+    waitInstanceBooted ovn1 ovn1
     ovn1NICIPv4="$(lxc list ovn1 -c4 --format=csv --project=ovn1 | cut -d' ' -f1)"
     ovn1NICIPv6="$(lxc list ovn1 -c6 --format=csv --project=ovn1 | cut -d' ' -f1)"
     lxc exec ovn2 -T -n --project=ovn2 -- ping -nc1 -4 -w5 "${ovn1NICIPv4}"
@@ -1374,7 +1374,7 @@ ovn_dhcp_reservation_tests() {
 
     # Launch new dynamic IP instance and check its not allocated the reserved IP.
     lxc launch "${instanceImage}" u2 -s default -n ovn1
-    waitInstanceReady u2
+    waitInstanceBooted u2
     lxc list
     U2_IPV4="$(lxc list u2 -c4 --format=csv | cut -d' ' -f1)"
     [ "${U2_IPV4}" != "10.10.11.2" ] || false
@@ -1476,8 +1476,8 @@ ovn_nested_vlan_tests() {
     lxc exec u1 -- ip netns exec vlan_nesting2 ip address add fd42:4242:4242:1011::11/64 dev eth0.2 nodad
     lxc exec u1 -- ip netns exec vlan_nesting2 ip link set eth0.2 up
 
-    waitInstanceReady u1
-    waitInstanceReady u2
+    waitInstanceBooted u1
+    waitInstanceBooted u2
     lxc list
     lxc exec u1 -- ip netns exec vlan_nesting1 ip address
     lxc exec u1 -- ip netns exec vlan_nesting2 ip address
@@ -1557,8 +1557,8 @@ ovn_acl_tests() {
     lxc launch "${instanceImage}" c2 -n ovn0 -s default
 
     echo "==> Wait for addresses"
-    waitInstanceReady c1
-    waitInstanceReady c2
+    waitInstanceBooted c1
+    waitInstanceBooted c2
     lxc list
 
     # Check per-NIC ACL rules added.
@@ -1709,7 +1709,7 @@ ovn_acl_tests() {
     lxc start c1
 
     echo "==> Wait for addresses"
-    waitInstanceReady c1
+    waitInstanceBooted c1
     lxc list
 
     # Ping to c1 instance from c2 should be blocked.
@@ -1849,8 +1849,8 @@ ovn_acl_tests() {
     lxc start c1
 
     echo "==> Wait for addresses"
-    waitInstanceReady c1
-    waitInstanceReady c2
+    waitInstanceBooted c1
+    waitInstanceBooted c2
     lxc list
 
     # Check c2 can ping external.
@@ -1907,8 +1907,8 @@ ovn_l3only_tests() {
     lxc launch "${instanceImage}" u1 -s default -n ovn1
     lxc launch "${instanceImage}" u2 -s default -n ovn1
 
-    waitInstanceReady u1
-    waitInstanceReady u2
+    waitInstanceBooted u1
+    waitInstanceBooted u2
     lxc list
 
     U1_IPV4="$(lxc list u1 -c4 --format=csv | cut -d' ' -f1)"

--- a/tests/network-routed
+++ b/tests/network-routed
@@ -52,7 +52,7 @@ EOF
 lxc start v1
 
 # Wait for VM to start.
-waitVMAgent v1
+waitInstanceReady v1
 sleep 10
 
 # Test ping to/from VM NIC.

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -95,10 +95,10 @@ lxc config device override v4 eth0 vlan=4000 security.mac_filtering=true
 lxc start v4
 
 # Wait for VMs to start.
-waitVMAgent v1
-waitVMAgent v2
-waitVMAgent v3
-waitVMAgent v4
+waitInstanceReady v1
+waitInstanceReady v2
+waitInstanceReady v3
+waitInstanceReady v4
 
 lxc list
 networkTests

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -69,7 +69,7 @@ lxc config device set v1 d1 source="${testRoot}/allowed1" shift=true
 # Check adding a disk with a source path that is allowed.
 lxc config device set v1 d1 source="${testRoot}/allowed1" shift=false
 lxc start v1
-waitVMAgent v1
+waitInstanceReady v1
 lxc exec v1 -- ls -l /mnt/foo1
 lxc stop -f v1
 
@@ -81,7 +81,7 @@ lxc config device set v1 d1 source="${testRoot}/allowed1/not-allowed2"
 # Check relative symlink inside allowed parent path is allowed.
 lxc config device set v1 d1 source="${testRoot}/allowed1/foolink" path=/mnt/foolink
 lxc start v1
-waitVMAgent v1
+waitInstanceReady v1
 [ "$(lxc exec v1  -- stat /mnt/foolink -c '%u:%g')" = "65534:65534" ] || false
 lxc stop -f v1
 
@@ -105,7 +105,7 @@ lxc config set v1 raw.idmap="both 1000 1000"
 # Check single entry raw.idmap has taken effect on disk share.
 lxc config device set v1 d1 source="${testRoot}/allowed1" path=/mnt
 lxc start v1 || (lxc info --show-log c1 ; false)
-waitVMAgent v1
+waitInstanceReady v1
 [ "$(lxc exec v1  -- stat /mnt/foo1 -c '%u:%g')" = "1000:1000" ] || false
 [ "$(lxc exec v1  -- stat /mnt/foo2 -c '%u:%g')" = "65534:65534" ] || false
 
@@ -114,7 +114,7 @@ if lxc exec v1 -- mount | grep -qwF /boot/efi; then
   lxc exec v1 -- mokutil --sb-state | grep -Fx "SecureBoot enabled"
   lxc profile set default security.secureboot=false
   lxc restart -f v1
-  waitVMAgent v1
+  waitInstanceReady v1
   lxc exec v1 -- mokutil --sb-state | grep -Fx "SecureBoot disabled"
 fi
 
@@ -129,7 +129,7 @@ if hasNeededAPIExtension disk_io_bus; then
   # Add a NVMe disk and check if a NVMe controller is added to the VM
   lxc config device add v1 nvme-ssd disk source="${loopdev}" io.bus=nvme
   lxc start v1
-  waitVMAgent v1
+  waitInstanceReady v1
   lxc exec v1 -- lspci | grep -F "QEMU NVM Express Controller"
 else
   echo 'Skipping NVME test due to missing extension: "disk_io_bus"'

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -30,7 +30,7 @@ do
         echo "==> Create VM and boot"
         lxc init ubuntu-daily:22.04 v1 --vm -s "${poolName}"
         lxc start v1
-        waitVMAgent v1
+        waitInstanceReady v1
         lxc info v1
 
         echo "==> Check /dev/disk/by-id"
@@ -60,20 +60,20 @@ do
 
         echo "==> Checking restore VM snapshot"
         lxc restore v1 snap0
-        waitVMAgent v1
+        waitInstanceReady v1
         lxc exec v1 -- cat /root/foo.txt | grep -Fx "foo"
 
         echo "==> Checking VM can be copied with snapshots"
         lxc copy v1 v2
         [ "$(lxc query /1.0/instances/v2?recursion=1 | jq '.snapshots | length')" -eq "1" ]
         lxc start v2
-        waitVMAgent v2
+        waitInstanceReady v2
         lxc delete -f v2
 
         echo "==> Checking running copied VM snapshot"
         lxc copy v1/snap0 v2
         lxc start v2
-        waitVMAgent v2
+        waitInstanceReady v2
         lxc exec v2 -- cat /root/foo.txt | grep -Fx "foo"
 
         echo "==> Checking VM snapshot copy root disk size is 10GiB"
@@ -95,7 +95,7 @@ do
         lxc stop v1 -f
         ! pgrep -af "${uuid}" || false
         lxc start v1
-        waitVMAgent v1
+        waitInstanceReady v1
 
         echo "==> Testing VM non-optimized export/import (while running to check config.mount is excluded)"
         lxc exec v1 -- fsfreeze --freeze /
@@ -104,7 +104,7 @@ do
         lxc import "/tmp/lxd-test-${poolName}.tar.gz"
         rm "/tmp/lxd-test-${poolName}.tar.gz"
         lxc start v1
-        waitVMAgent v1
+        waitInstanceReady v1
 
         echo "==> Testing VM optimized export/import (while running to check config.mount is excluded)"
         lxc exec v1 -- fsfreeze --freeze /
@@ -113,14 +113,14 @@ do
         lxc import "/tmp/lxd-test-${poolName}-optimized.tar.gz"
         rm "/tmp/lxd-test-${poolName}-optimized.tar.gz"
         lxc start v1
-        waitVMAgent v1
+        waitInstanceReady v1
 
         echo "==> Increasing VM root disk size for next boot"
         lxc config device set v1 root size=11GiB
         lxc config get v1 volatile.root.apply_quota | grep true
         lxc stop -f v1
         lxc start v1
-        waitVMAgent v1
+        waitInstanceReady v1
 
         echo "==> Checking VM root disk size is 11GiB"
         [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "11" ]
@@ -144,7 +144,7 @@ do
         lxc config device add v1 block1ro disk source="/tmp/lxd-test-${poolName}/lxd-test-block" readonly=true
         lxc config device add v1 block1rw disk source="/tmp/lxd-test-${poolName}/lxd-test-block"
         lxc start v1
-        waitVMAgent v1
+        waitInstanceReady v1
 
         echo "==> Testing VM lxd-agent drive mounts"
         # Check there is only 1 mount for each directory disk and that it is mounted with the appropriate options.
@@ -209,7 +209,7 @@ do
 
         echo "==> Checking disk device hotplug support"
         lxc launch ubuntu-daily:22.04 v1 --vm -s "${poolName}"
-        waitVMAgent v1
+        waitInstanceReady v1
 
         # Hotplug disks
         lxc storage volume create "${poolName}" vol1 --type=block size=10MB
@@ -252,7 +252,7 @@ do
         lxc storage set "${poolName}" volume.size 6GiB
         lxc init ubuntu-daily:22.04 v1 --vm -s "${poolName}"
         lxc start v1
-        waitVMAgent v1
+        waitInstanceReady v1
         lxc info v1
 
         echo "==> Checking VM root disk size is 6GiB"
@@ -267,7 +267,7 @@ do
                 lxc storage set "${poolName}" volume.block.filesystem xfs
                 lxc init ubuntu-daily:22.04 v1 --vm -s "${poolName}"
                 lxc start v1
-                waitVMAgent v1
+                waitInstanceReady v1
                 lxc info v1
 
                 echo "==> Checking VM config disk filesyste is XFS"
@@ -284,7 +284,7 @@ do
         lxc profile device add vmsmall root disk pool="${poolName}" path=/ size=7GiB
         lxc init ubuntu-daily:22.04 v1 --vm -p vmsmall
         lxc start v1
-        waitVMAgent v1
+        waitInstanceReady v1
         lxc info v1
 
         echo "==> Checking VM root disk size is 7GiB"
@@ -304,7 +304,7 @@ do
 
         lxc copy v1 v2 -s "${poolName}2"
         lxc start v2
-        waitVMAgent v2
+        waitInstanceReady v2
         lxc info v2
 
         echo "==> Checking copied VM root disk size is 7GiB"
@@ -321,7 +321,7 @@ do
         lxc storage create "${poolName}2" "${dstPoolDriver}" size=20GiB
         lxc copy v1 v2 -s "${poolName}2"
         lxc start v2
-        waitVMAgent v2
+        waitInstanceReady v2
         lxc info v2
 
         echo "==> Checking copied VM root disk size is 7GiB"
@@ -332,7 +332,7 @@ do
         lxc config device override v1 root size=11GiB
         lxc copy v1 v2 -s "${poolName}2"
         lxc start v2
-        waitVMAgent v2
+        waitInstanceReady v2
         lxc info v2
 
         echo "==> Checking copied VM root disk size is 11GiB"
@@ -342,7 +342,7 @@ do
 
         echo "==> Publishing larger VM"
         lxc start v1 # Start to ensure cloud-init grows filesystem before publish.
-        waitVMAgent v1
+        waitInstanceReady v1
         lxc info v1
         lxc stop -f v1
         lxc publish v1 --alias vmbig
@@ -356,7 +356,7 @@ do
         lxc storage unset "${poolName}" volume.size
         lxc init vmbig v1 --vm -s "${poolName}"
         lxc start v1
-        waitVMAgent v1
+        waitInstanceReady v1
         lxc info v1
 
         echo "==> Checking new VM root disk size is 11GiB"
@@ -374,7 +374,7 @@ do
         echo "==> Checking VM Generation UUID with QEMU"
         lxc init ubuntu-daily:22.04 v1 --vm -s "${poolName}"
         lxc start v1
-        waitVMAgent v1
+        waitInstanceReady v1
         lxc info v1
 
         # Check that the volatile.uuid.generation setting is applied to the QEMU process.

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -47,7 +47,7 @@ do
 
 	echo "==> Start VM and add content to custom block volume"
 	lxc start v1
-	waitVMAgent v1
+	waitInstanceReady v1
 
 	lxc exec v1 -- /bin/sh -c "mkfs.ext4 /dev/sdb && mount /dev/sdb /mnt && echo foo > /mnt/bar && umount /mnt"
 
@@ -93,8 +93,8 @@ do
 	echo "==> Start VM and check content"
 	lxc start v1
 	lxc start v2
-	waitVMAgent v1
-	waitVMAgent v2
+	waitInstanceReady v1
+	waitInstanceReady v2
 
 	# shellcheck disable=2016
 	lxc exec v1 -- /bin/sh -c 'mount /dev/sdb /mnt && [ $(cat /mnt/bar) = foo ] && umount /mnt'
@@ -128,7 +128,7 @@ do
 	lxc config set storage.images_volume "${poolName}"/images
 	lxc publish v1 --alias v1image
 	lxc launch v1image v2 -s "${poolName}"
-	waitVMAgent v2
+	waitInstanceReady v2
 	lxc delete v2 -f
 	lxc image delete v1image
 	lxc config unset storage.images_volume


### PR DESCRIPTION
`waitInstanceReady()`: used to wait for the instance to report a processes count greater than 1
`waitInstanceBooted()`: used to wait for the instance be fully booted

@tomponline for `waitInstanceBooted()`, I couldn't find a way around the `Failed to connect to bus: No such file or directory` issue you ran into so I added a `sleep 1` :/ At least it worked twice without running into that specific issue.

While in there, also add a workaround for https://github.com/canonical/lxd/issues/12659 in `tests/cgroup` and mark the test as incompatible with `-kvm` kernel flavor.