### PR TITLE
Make `tests/gpu-container` adapt to available HW

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -90,6 +90,7 @@ enableNICSRIOV() (
 
 # install_deps: install dependencies if needed.
 install_deps() (
+    set +x
     PKGS="${*}"
     missing=""
     PKGS_LIST="$(dpkg --get-selections | awk '{print $1}')"

--- a/bin/helpers
+++ b/bin/helpers
@@ -128,6 +128,11 @@ install_lxd() (
     uname -a
     cat /proc/cmdline
     lxd waitready --timeout=300
+
+    # Silence the "If this is your first time running LXD on this machine" banner
+    # on first invocation
+    mkdir -p ~/snap/lxd/common/config/
+    touch ~/snap/lxd/common/config/config.yml
 )
 
 # hasNeededAPIExtension: check if LXD supports the needed extension.

--- a/bin/helpers
+++ b/bin/helpers
@@ -161,15 +161,16 @@ runsMinimumKernel() (
 
 # cleanup: report if the test passed or not and return the appropriate return code.
 cleanup() {
-    # Run any extra cleanup function
-    if command -v extra_cleanup > /dev/null; then
-      extra_cleanup || true
-    fi
-
+    set +e
     echo ""
     if [ "${FAIL}" = "1" ]; then
         echo "Test failed"
         exit 1
+    fi
+
+    # Run any extra cleanup function only on success
+    if command -v extra_cleanup > /dev/null; then
+      extra_cleanup || true
     fi
 
     echo "Test passed"

--- a/bin/testflinger-run
+++ b/bin/testflinger-run
@@ -9,9 +9,13 @@ shift 4
 _script="$(mktemp)"
 test_name="$(basename "${script}")"
 
+# Look in the test script if there is a suggested queue
+queue="$(awk '/^# testflinger_queue:/ {print $3}' "${script}")"
+queue="${queue:-anything}"
+
 testflinger_yaml_job() {
     cat << EOF
-job_queue: anything
+job_queue: ${queue}
 provision_data:
   distro: ${serie}
 test_data:

--- a/bin/testflinger-run
+++ b/bin/testflinger-run
@@ -23,7 +23,7 @@ test_data:
     SSH="ssh -n \$SSH_OPTS"
 
     # Get lxd-ci scripts
-    git clone https://github.com/canonical/lxd-ci.git
+    git clone --depth 1 https://github.com/canonical/lxd-ci.git
     cd lxd-ci
 
     # wait for a machine to be ready

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -35,6 +35,18 @@ lxc profile device add default root disk path=/ pool=default
 lxc network create lxdbr0
 lxc profile device add default eth0 nic network=lxdbr0 name=eth0
 
+# Consult available resources
+total_gpu="$(lxc query /1.0/resources | jq -r '.gpu.total')"
+total_nvidia_gpu="$(lxc query /1.0/resources | jq -r '.gpu.cards | .[] | select(.driver == "nvidia") | .pci_address' | wc -l)"
+first_card_pci_slot="$(lxc query /1.0/resources | jq -r '.gpu.cards | .[] | select(.driver == "nvidia") | .pci_address' | head -n1)"
+first_card_product_id="$(lxc query /1.0/resources | jq -r ".gpu.cards | .[] | select(.pci_address == \"${first_card_pci_slot}\") | .product_id")"
+total_nvidia_gpu_with_product_id="$(lxc query /1.0/resources | jq -r ".gpu.cards | .[] | select(.product_id == \"${first_card_product_id}\") | .product_id" | wc -l)"
+
+# Check if available resources are sufficient
+[ "${total_gpu}" -gt 1 ]
+[ "${total_nvidia_gpu}" -ge 1 ]
+[ "${total_nvidia_gpu_with_product_id}" -ge 1 ]
+
 # Launch a test container
 echo "==> Launching a test container"
 lxc launch ubuntu-daily:22.04 c1
@@ -57,10 +69,10 @@ sleep 1
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "0" ] || false
 
 # Validate with all GPUs
-echo "==> Testing with all GPUs"
+echo "==> Testing with all NVIDIA GPUs"
 lxc config device add c1 gpus gpu
 sleep 1
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "${total_gpu}" ] || false
 
 # Test nvidia runtime
 echo "==> Testing nvidia runtime"
@@ -74,7 +86,7 @@ lxc exec c1 -- nvidia-smi
 # Test with PCI addresses
 echo "==> Testing PCI address selection"
 lxc config device remove c1 gpus
-lxc config device add c1 gpu1 gpu pci=0000:06:00.0
+lxc config device add c1 gpu1 gpu pci="${first_card_pci_slot}"
 sleep 1
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 lxc exec c1 -- nvidia-smi
@@ -84,15 +96,15 @@ echo "==> Testing PCI vendor selection"
 lxc config device remove c1 gpu1
 lxc config device add c1 gpus gpu vendorid=10de
 sleep 1
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "${total_nvidia_gpu}" ] || false
 lxc exec c1 -- nvidia-smi
 
 # Test with vendor and product
 echo "==> Testing PCI vendor and product selection"
 lxc config device remove c1 gpus
-lxc config device add c1 gpus gpu vendorid=10de productid=27b8
+lxc config device add c1 gpus gpu vendorid=10de productid="${first_card_product_id}"
 sleep 1
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "${total_nvidia_gpu_with_product_id}" ] || false
 lxc exec c1 -- nvidia-smi
 
 # shellcheck disable=SC2034

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eu
+set -eux
 
 # testflinger_queue: rockman
 

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -38,7 +38,7 @@ lxc profile device add default eth0 nic network=lxdbr0 name=eth0
 # Launch a test container
 echo "==> Launching a test container"
 lxc launch ubuntu-daily:22.04 c1
-sleep 10
+waitInstanceReady c1
 
 # Confirm no GPU
 echo "==> Testing with no GPU"
@@ -65,6 +65,7 @@ echo "==> Testing nvidia runtime"
 lxc stop c1
 lxc config set c1 nvidia.runtime true
 lxc start c1
+waitInstanceReady c1
 lxc exec c1 -- nvidia-smi
 
 # Test with PCI addresses

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -47,16 +47,19 @@ echo "==> Testing with no GPU"
 # Validate with one GPU
 echo "==> Testing with one GPU"
 lxc config device add c1 gpu0 gpu id=0
+sleep 1
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 
 # Validate with all remove
 echo "==> Testing with no GPU"
 lxc config device remove c1 gpu0
+sleep 1
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "0" ] || false
 
 # Validate with all GPUs
 echo "==> Testing with all GPUs"
 lxc config device add c1 gpus gpu
+sleep 1
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 
 # Test nvidia runtime
@@ -72,6 +75,7 @@ lxc exec c1 -- nvidia-smi
 echo "==> Testing PCI address selection"
 lxc config device remove c1 gpus
 lxc config device add c1 gpu1 gpu pci=0000:06:00.0
+sleep 1
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 lxc exec c1 -- nvidia-smi
 
@@ -79,6 +83,7 @@ lxc exec c1 -- nvidia-smi
 echo "==> Testing PCI vendor selection"
 lxc config device remove c1 gpu1
 lxc config device add c1 gpus gpu vendorid=10de
+sleep 1
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 lxc exec c1 -- nvidia-smi
 
@@ -86,6 +91,7 @@ lxc exec c1 -- nvidia-smi
 echo "==> Testing PCI vendor and product selection"
 lxc config device remove c1 gpus
 lxc config device add c1 gpus gpu vendorid=10de productid=27b8
+sleep 1
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 lxc exec c1 -- nvidia-smi
 

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -29,6 +29,14 @@ install_lxd
 # Check that NVIDIA is installed
 nvidia-smi
 
+extra_cleanup() {
+  lxc delete -f c1
+  lxc profile device remove default root
+  lxc profile device remove default eth0
+  lxc storage delete default
+  lxc network delete lxdbr0
+}
+
 # Configure LXD
 lxc storage create default zfs
 lxc profile device add default root disk path=/ pool=default

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eu
 
+# testflinger_queue: rockman
+
 # Install required components from "restricted" pocket
 if ! grep -v '^#' /etc/apt/sources.list | grep -qwFm1 restricted; then
     ARCH="$(dpkg --print-architecture)"


### PR DESCRIPTION
This was tested on `rockman` using:

```
PURGE_LXD=1 ./bin/local-run tests/gpu-container latest/edge
```

`rockman` has the particularity of having 3 GPUs, one onboard Matrox and 2x NVIDIA L40.