### PR TITLE
Improve `tests/gpu-container` to pick the recommended driver series and abort on secureboot enabled

### DIFF
--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -26,7 +26,9 @@ if mokutil --sb-state | grep -Fx "SecureBoot enabled"; then
 fi
 
 # Install dependencies
-INSTALL_RECOMMENDS=yes install_deps jq nvidia-utils-525 nvidia-driver-525
+install_deps jq ubuntu-drivers-common
+RECOMMENDED_DRIVER="$(ubuntu-drivers devices 2>/dev/null | awk '/nvidia-driver-.*recommended$/ {print $3}')"
+INSTALL_RECOMMENDS=yes install_deps "${RECOMMENDED_DRIVER}"
 
 # Install LXD
 install_lxd

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -20,6 +20,11 @@ EOF
     fi
 fi
 
+if mokutil --sb-state | grep -Fx "SecureBoot enabled"; then
+  echo "SecureBoot needs to be disabled to avoid a prompt to register custom MOK (Machine-Owner Key) during DKMS" >&2
+  exit 1
+fi
+
 # Install dependencies
 INSTALL_RECOMMENDS=yes install_deps jq nvidia-utils-525 nvidia-driver-525
 

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -21,7 +21,7 @@ EOF
 fi
 
 # Install dependencies
-INSTALL_RECOMMENDS=yes install_deps nvidia-utils-525 nvidia-driver-525
+INSTALL_RECOMMENDS=yes install_deps jq nvidia-utils-525 nvidia-driver-525
 
 # Install LXD
 install_lxd


### PR DESCRIPTION
Based on comments/suggestion from https://github.com/canonical/lxd-ci/pull/50#issuecomment-1858451719

@escabo, this addresses your feedback  however I couldn't find a nice way to avoid DKMS triggering the onboarding of custom MOKs and thus prompting for password. The test will warn and bail if secureboot is enabled.

@tomponline this was tested successfully on `rockman`.