### PR TITLE
Polish `tests/network-sriov` test

### DIFF
--- a/tests/main-testflinger
+++ b/tests/main-testflinger
@@ -50,11 +50,10 @@ run_test jammy default tests/devlxd-vm "${lxd_snap_channel}"
 #run_test jammy default tests/docker "${lxd_snap_channel}"
 
 # gpu
-# XXX: requires nvidia graphic card to be present in the host and to
-# know which PCI address it has
-#run_test jammy default tests/gpu-container "${lxd_snap_channel}"
+# XXX: requires nvidia graphic card to be present in the host
+run_test jammy default tests/gpu-container "${lxd_snap_channel}"
 # XXX: requires a specific nvidia graphic card to be present in the host
-#run_test jammy default tests/gpu-mig "${lxd_snap_channel}"
+run_test jammy default tests/gpu-mig "${lxd_snap_channel}"
 # XXX: requires nvidia graphic card to be present in the host and a
 # compatible driver to be installed
 #run_test jammy default tests/gpu-vm "${lxd_snap_channel}" nvidia

--- a/tests/main-testflinger
+++ b/tests/main-testflinger
@@ -71,7 +71,7 @@ run_test jammy hwe tests/network-bridge-firewall "${lxd_snap_channel}"
 run_test jammy default tests/network-ovn "${lxd_snap_channel}"
 run_test jammy default tests/network-routed "${lxd_snap_channel}"
 # XXX: requires SR-IOV capable NIC
-#run_test jammy default tests/network-sriov "${lxd_snap_channel}"
+run_test jammy default tests/network-sriov "${lxd_snap_channel}"
 
 # pylxd
 run_test jammy default tests/pylxd "${lxd_snap_channel}"

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -70,7 +70,7 @@ networkTests() {
         fi
 
         # DNS resolution
-        if lxc exec "${name}" -- getent hosts linuxcontainers.org >/dev/null 2>&1 || lxc exec "${name}" -- ping -c1 -W1 linuxcontainers.org >/dev/null 2>&1; then
+        if lxc exec "${name}" -- getent hosts archive.ubuntu.com >/dev/null 2>&1; then
             echo "PASS: DNS resolution: ${name}"
         else
             echo "FAIL: DNS resolution: ${name}"

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -9,7 +9,13 @@ install_lxd
 # Install dependencies
 install_deps jq
 
-parentNIC="${1}"
+parentNIC="${1:-}"
+
+if [ -z "${parentNIC}" ]; then
+  # Consult available resources
+  first_sriov_nic="$(lxc query /1.0/resources | jq -r '[.network.cards | .[] | select(.sriov != null) | .ports][0] | .[0].id')"
+  parentNIC="${first_sriov_nic}"
+fi
 
 # Enable SR-IOV on nic and bring up
 enableNICSRIOV "${parentNIC}"

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -145,7 +145,10 @@ lxc config device override c4 eth0 vlan=4000 security.mac_filtering=true
 lxc start c4
 
 # Wait for containers to start.
-sleep 30s
+waitInstanceReady c1
+waitInstanceReady c2
+waitInstanceReady c3
+waitInstanceReady c4
 
 lxc list
 networkTests

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -76,6 +76,14 @@ networkTests() {
             echo "FAIL: DNS resolution: ${name}"
             FAIL=1
         fi
+
+        # TCP connectivity
+        if lxc exec "${name}" -- nc -zv archive.ubuntu.com 80 >/dev/null 2>&1; then
+            echo "PASS: TCP connectivity: ${name}"
+        else
+            echo "FAIL: TCP connectivity: ${name}"
+            FAIL=1
+        fi
     done
 
     if [ "${FAIL}" = "1" ]; then

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -101,21 +101,21 @@ lxc profile device add default eth0 nic nictype=sriov parent="${parentNIC}" name
 # Launch a few VMs.
 # Do this first before containers to ensure VF free search handles VFs unbound from host.
 echo "==> VM on default VLAN"
-lxc init ubuntu-daily:23.10 v1 --vm
+lxc init ubuntu-daily:24.04 v1 --vm
 lxc start v1
 
 echo "==> VM on default VLAN with filtering"
-lxc init ubuntu-daily:23.10 v2 --vm
+lxc init ubuntu-daily:24.04 v2 --vm
 lxc config device override v2 eth0 security.mac_filtering=true
 lxc start v2
 
 echo "==> VM on alternate VLAN"
-lxc init ubuntu-daily:23.10 v3 --vm
+lxc init ubuntu-daily:24.04 v3 --vm
 lxc config device override v3 eth0 vlan=4000
 lxc start v3
 
 echo "==> VM on alternate VLAN with filtering"
-lxc init ubuntu-daily:23.10 v4 --vm
+lxc init ubuntu-daily:24.04 v4 --vm
 lxc config device override v4 eth0 vlan=4000 security.mac_filtering=true
 lxc start v4
 

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -3,6 +3,12 @@ set -eux
 
 # testflinger_queue: luma
 
+# Check if IOMMU is configured
+if [ -n "$(find /sys/kernel/iommu_groups/ -empty)" ]; then
+    echo "System not IOMMU ready, hint: \"./bin/custom-kernel iommu\"" >&2
+    exit 1
+fi
+
 # Install LXD
 install_lxd
 

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -54,7 +54,7 @@ networkTests() {
         fi
 
         # IPv4 address
-        if echo "${address}" | grep "\." -q; then
+        if echo "${address}" | grep -qF "."; then
             echo "PASS: IPv4 address: ${name}"
         else
             echo "FAIL: IPv4 address: ${name}"
@@ -62,7 +62,7 @@ networkTests() {
         fi
 
         # IPv6 address
-        if echo "${address}" | grep ":" -q; then
+        if echo "${address}" | grep -qF ":"; then
             echo "PASS: IPv6 address: ${name}"
         else
             echo "WARN: IPv6 address: ${name}"

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eu
+set -eux
 
 # Install LXD
 install_lxd

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -65,8 +65,8 @@ networkTests() {
         if echo "${address}" | grep ":" -q; then
             echo "PASS: IPv6 address: ${name}"
         else
-            echo "FAIL: IPv6 address: ${name}"
-            FAIL=1
+            echo "WARN: IPv6 address: ${name}"
+            #FAIL=1
         fi
 
         # DNS resolution

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eux
 
+# testflinger_queue: luma
+
 # Install LXD
 install_lxd
 

--- a/tests/network-sriov
+++ b/tests/network-sriov
@@ -6,6 +6,9 @@ set -eux
 # Install LXD
 install_lxd
 
+# Install dependencies
+install_deps jq
+
 parentNIC="${1}"
 
 # Enable SR-IOV on nic and bring up


### PR DESCRIPTION
The test now tries to pick the first SR-IOV capable NIC if none was provided. This allows automatic testing through `testflinger` on `luma`. There unfortunately, IPv6 is not enabled so I had to make the script warn instead of hard failing.

Also, since we are close to having `24.04`, I opted to switch the VMs from `23.10` to `24.04` as it works with it as well.

This was tested successfully with `5.0/edge` and `latest/edge`.