### PR TITLE
Misc fixes

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -3,15 +3,10 @@
 # waitSnapdSeed: wait for snapd to be seeded.
 waitSnapdSeed() (
   set +x
-  for i in $(seq 60); do # Wait up to 60s.
-    if systemctl show snapd.seeded.service --value --property SubState | grep -qx exited; then
-      return 0 # Success.
-    fi
-
-    sleep 1
-  done
-
-  echo "snapd not seeded after ${i}s"
+  if timeout 60 snap wait system seed.loaded; then
+    return 0 # Success.
+  fi
+  echo "snapd not seeded after 60s"
   return 1 # Failed.
 )
 

--- a/bin/openstack-run
+++ b/bin/openstack-run
@@ -101,7 +101,7 @@ if echo "${IP}" | grep -q ":"; then
 else
     scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "${_script}" "ubuntu@${IP}:test-script"
 fi
-ssh -n -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "ubuntu@${IP}" sudo "https_proxy=http://squid.internal:3128" bash test-script "$@"
+ssh -n -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "ubuntu@${IP}" sudo "https_proxy=http://squid.internal:3128" "PURGE_LXD=1" bash test-script "$@"
 
 # Success
 RET=0

--- a/bin/openstack-run
+++ b/bin/openstack-run
@@ -21,7 +21,7 @@ _script="$(mktemp)"
 test_name="$(basename "${script}")"
 
 KEY_NAME="ssh-key"
-FLAVOR="$(openstack flavor list -f value -c Name | grep -m1 'cpu8-ram32-disk20\b')"
+FLAVOR="$(openstack flavor list -f value -c Name | grep -m1 'cpu8-ram32-disk50\b')"
 NETWORK="$(openstack network list -f value -c Name | grep -Fm1 "net_stg-lxd-cloud-testing")"
 IMAGE="$(openstack image list -f value -c Name --sort-column Name --sort-descending | grep -m1 "auto-sync/ubuntu-${serie}-.*-amd64-")"
 NAME="lxd-ci-${test_name}-${serie}-$(echo "${lxd_snap_channel}" | sed 's/[./]/-/g')"

--- a/bin/testflinger-run
+++ b/bin/testflinger-run
@@ -66,7 +66,7 @@ test_data:
     \$SCP "\${_script}" "ubuntu@\${DEVICE_IP}:test-script"
 
     # Run the test
-    \$SSH "ubuntu@\${DEVICE_IP}" -- sudo bash test-script $@
+    \$SSH "ubuntu@\${DEVICE_IP}" -- sudo "PURGE_LXD=1" bash test-script $@
 EOF
 }
 

--- a/tests/cgroup
+++ b/tests/cgroup
@@ -23,7 +23,7 @@ set -x
 
 # Start a container with no limits
 echo "=> Start a container with no limits"
-lxc launch "${TEST_IMG:-ubuntu-daily:22.04}" c1
+lxc launch "${TEST_IMG:-ubuntu-minimal-daily:22.04}" c1
 
 echo "==> Validate default values"
 [ "$(lxc exec c1 -- nproc)" = "$(nproc)" ]

--- a/tests/cluster
+++ b/tests/cluster
@@ -40,13 +40,14 @@ extra_cleanup() {
 # Launch the container
 lxc launch "${TEST_IMG:-ubuntu-daily:22.04}" "${PREFIX}-1" -c security.nesting=true -c security.devlxd.images=true
 
-sleep 10
+waitInstanceBooted "${PREFIX}-1"
 
 lxc exec "${PREFIX}-1" -- snap refresh lxd --channel="$2"
 
 for i in $(seq 2 "$1"); do
     lxc copy "${PREFIX}-1" "${PREFIX}-$i"
     lxc start "${PREFIX}-$i"
+    waitInstanceBooted "${PREFIX}-$i"
 done
 
 for i in $(seq "$1"); do

--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -79,11 +79,10 @@ lxc stop -f v1
 sleep 5
 [ "$(lxc config get v1 volatile.last_state.ready)" = "false" ]
 
-# Test nested VM functionality.
 lxc start v1
 waitInstanceReady v1
 
-# Configure to use the proxy
+# Test nested VM functionality.
 lxc exec v1 -- snap wait system seed.loaded
 lxc exec v1 -- snap remove --purge lxd || true
 lxc exec v1 -- snap install lxd --channel="${LXD_SNAP_CHANNEL}"

--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -66,21 +66,25 @@ lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/devi
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/config | jq
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q '#cloud-config'
 
-# test instance Ready state
-lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock -X PATCH -d '{"state":"Ready"}' http://custom.socket/1.0
-[ "$(lxc config get v1 volatile.last_state.ready)" = "true" ]
+if hasNeededAPIExtension instance_ready_state; then
+  # test instance Ready state
+  lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock -X PATCH -d '{"state":"Ready"}' http://custom.socket/1.0
+  [ "$(lxc config get v1 volatile.last_state.ready)" = "true" ]
 
-lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock -X PATCH -d '{"state":"Started"}' http://custom.socket/1.0
-[ "$(lxc config get v1 volatile.last_state.ready)" = "false" ]
+  lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock -X PATCH -d '{"state":"Started"}' http://custom.socket/1.0
+  [ "$(lxc config get v1 volatile.last_state.ready)" = "false" ]
 
-lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock -X PATCH -d '{"state":"Ready"}' http://custom.socket/1.0
-[ "$(lxc config get v1 volatile.last_state.ready)" = "true" ]
-lxc stop -f v1
-sleep 5
-[ "$(lxc config get v1 volatile.last_state.ready)" = "false" ]
+  lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock -X PATCH -d '{"state":"Ready"}' http://custom.socket/1.0
+  [ "$(lxc config get v1 volatile.last_state.ready)" = "true" ]
+  lxc stop -f v1
+  sleep 5
+  [ "$(lxc config get v1 volatile.last_state.ready)" = "false" ]
 
-lxc start v1
-waitInstanceReady v1
+  lxc start v1
+  waitInstanceReady v1
+else
+  echo "Skipping instance Ready state tests, not supported"
+fi
 
 # Test nested VM functionality.
 lxc exec v1 -- snap wait system seed.loaded

--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -87,7 +87,7 @@ lxc exec v1 -- snap wait system seed.loaded
 lxc exec v1 -- snap remove --purge lxd || true
 lxc exec v1 -- snap install lxd --channel="${LXD_SNAP_CHANNEL}"
 lxc exec v1 -- /snap/bin/lxd init --auto
-lxc exec v1 -- /snap/bin/lxc launch "${TEST_IMG:-ubuntu-daily:22.04}" v1v1 --vm
+lxc exec v1 -- /snap/bin/lxc launch "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1v1 --vm
 sleep 30
 lxc exec v1 -- /snap/bin/lxc info v1v1 | grep -F RUNNING
 

--- a/tests/docker
+++ b/tests/docker
@@ -37,6 +37,8 @@ for BIN in docker dockerd docker-containerd docker-containerd-shim docker-init d
         chmod +x "/usr/bin/\${BIN}"
 done
 
+unset https_proxy
+
 # Start docker again
 systemctl start docker
 sleep 5

--- a/tests/docker
+++ b/tests/docker
@@ -29,8 +29,7 @@ apt-get update
 apt-get install --no-install-recommends --yes docker.io busybox-static
 
 # Stop the distro docker
-systemctl stop docker.service
-systemctl stop docker.socket
+systemctl stop docker.service docker.socket
 
 # Download binaries built from current git head of the Docker repo.
 for BIN in docker dockerd docker-containerd docker-containerd-shim docker-init docker-proxy docker-runc; do

--- a/tests/docker
+++ b/tests/docker
@@ -33,7 +33,7 @@ systemctl stop docker.service docker.socket
 
 # Download binaries built from current git head of the Docker repo.
 for BIN in docker dockerd docker-containerd docker-containerd-shim docker-init docker-proxy docker-runc; do
-    wget -q "https://master.dockerproject.org/linux/x86_64/\${BIN}" -O "/usr/bin/\${BIN}" && \
+    wget "https://master.dockerproject.org/linux/x86_64/\${BIN}" -O "/usr/bin/\${BIN}" && \
         chmod +x "/usr/bin/\${BIN}"
 done
 

--- a/tests/docker
+++ b/tests/docker
@@ -26,7 +26,7 @@ set -eux
 
 # Install distro docker
 apt-get update
-apt-get install --no-install-recommends --yes --force-yes docker.io busybox-static
+apt-get install --no-install-recommends --yes docker.io busybox-static
 
 # Stop the distro docker
 systemctl stop docker.service

--- a/tests/docker
+++ b/tests/docker
@@ -10,7 +10,7 @@ lxd init --auto
 CNAME="docker-$$"
 
 # Create the container
-lxc launch "${TEST_IMG:-ubuntu-daily:22.04}" "${CNAME}" -c security.nesting=true "$@"
+lxc launch "${TEST_IMG:-ubuntu-minimal-daily:22.04}" "${CNAME}" -c security.nesting=true "$@"
 
 (
 cat << EOF

--- a/tests/docker
+++ b/tests/docker
@@ -37,14 +37,14 @@ done
 systemctl start docker
 sleep 5
 
+# Show docker info (client and daemon version, etc.)
+docker info
+
 # Test whether we can pull a simple Docker image.
 docker pull busybox:latest
 
 # Test whether we can remove a simple Docker image.
 docker rmi busybox:latest
-
-# Show docker info (client and daemon version, etc.)
-docker info
 
 # Run a basic hello-world
 docker run hello-world

--- a/tests/docker
+++ b/tests/docker
@@ -12,6 +12,11 @@ CNAME="docker-$$"
 # Create the container
 lxc launch "${TEST_IMG:-ubuntu-minimal-daily:22.04}" "${CNAME}" -c security.nesting=true "$@"
 
+if [ -n "${https_proxy:-""}" ]; then
+  echo "Using https_proxy=${https_proxy} in ${CNAME}"
+  lxc config set "${CNAME}" environment.https_proxy="${https_proxy}"
+fi
+
 (
 cat << EOF
 #!/bin/sh

--- a/tests/docker
+++ b/tests/docker
@@ -21,7 +21,7 @@ set -eux
 
 # Install distro docker
 apt-get update
-apt-get install --no-install-recommends --yes --force-yes docker.io
+apt-get install --no-install-recommends --yes --force-yes docker.io busybox-static
 
 # Stop the distro docker
 systemctl stop docker.service
@@ -40,14 +40,22 @@ sleep 5
 # Show docker info (client and daemon version, etc.)
 docker info
 
-# Test whether we can pull a simple Docker image.
-docker pull busybox:latest
-
-# Test whether we can remove a simple Docker image.
-docker rmi busybox:latest
+# Test whether we can build a simple Docker image.
+rm -rf busybox
+mkdir busybox
+cat << EOD > busybox/Dockerfile
+FROM scratch
+ADD echo /
+ENTRYPOINT ["/echo", "Hello world"]
+EOD
+cp "\$(command -v busybox)" busybox/echo
+docker builder build --tag local:hello busybox/
 
 # Run a basic hello-world
-docker run hello-world
+docker run --rm local:hello
+
+# Test whether we can remove a simple Docker image.
+docker image rm local:hello
 EOF
 ) | lxc exec "${CNAME}" -- sh -eux
 

--- a/tests/main-openstack
+++ b/tests/main-openstack
@@ -31,7 +31,8 @@ run_test jammy default tests/cgroup "${lxd_snap_channel}"
 #run_test jammy cgroup1 tests/cgroup "${lxd_snap_channel}"
 run_test jammy swapaccount tests/cgroup "${lxd_snap_channel}"
 run_test focal default tests/cgroup "${lxd_snap_channel}"
-run_test focal swapaccount tests/cgroup "${lxd_snap_channel}"
+# https://github.com/canonical/lxd-ci/issues/7
+#run_test focal swapaccount tests/cgroup "${lxd_snap_channel}"
 
 # cluster (upgrade from XX/stable -> ${lxd_snap_channel})
 cluster_snap_src_channel="$(echo "${lxd_snap_channel}" | cut -d/ -f1)/stable"

--- a/tests/main-openstack
+++ b/tests/main-openstack
@@ -33,8 +33,9 @@ run_test jammy swapaccount tests/cgroup "${lxd_snap_channel}"
 run_test focal default tests/cgroup "${lxd_snap_channel}"
 run_test focal swapaccount tests/cgroup "${lxd_snap_channel}"
 
-# cluster
-#run_test jammy default tests/cluster "${lxd_snap_channel}" 3 "5.0/stable" "${lxd_snap_channel}"
+# cluster (upgrade from XX/stable -> ${lxd_snap_channel})
+cluster_snap_src_channel="$(echo "${lxd_snap_channel}" | cut -d/ -f1)/stable"
+run_test jammy default tests/cluster "${lxd_snap_channel}" 3 "${cluster_snap_src_channel}" "${lxd_snap_channel}"
 
 # cpu-vm
 run_test jammy default tests/cpu-vm "${lxd_snap_channel}"

--- a/tests/main-openstack
+++ b/tests/main-openstack
@@ -64,7 +64,8 @@ if echo "${lxd_snap_channel}" | grep -qE "^(latest|5\.[1-9].)/"; then
 fi
 
 # network
-run_test jammy default tests/network "${lxd_snap_channel}"
+# XXX: requires SR-IOV capable NIC
+#run_test jammy default tests/network "${lxd_snap_channel}"
 run_test jammy default tests/network-bridge-firewall "${lxd_snap_channel}"
 run_test jammy hwe tests/network-bridge-firewall "${lxd_snap_channel}"
 run_test jammy default tests/network-ovn "${lxd_snap_channel}"

--- a/tests/main-openstack
+++ b/tests/main-openstack
@@ -45,7 +45,7 @@ run_test jammy default tests/cpu-vm "${lxd_snap_channel}"
 run_test jammy default tests/devlxd-vm "${lxd_snap_channel}"
 
 # docker
-# XXX: unable to pull docker image due to rate limiting done by docker hub
+# XXX: master.dockerproject.org isn't authorized at the proxy level
 #run_test jammy default tests/docker "${lxd_snap_channel}"
 
 # gpu

--- a/tests/main-testflinger
+++ b/tests/main-testflinger
@@ -48,8 +48,7 @@ run_test jammy default tests/cpu-vm "${lxd_snap_channel}"
 run_test jammy default tests/devlxd-vm "${lxd_snap_channel}"
 
 # docker
-# XXX: unable to pull docker image due to rate limiting done by docker hub
-#run_test jammy default tests/docker "${lxd_snap_channel}"
+run_test jammy default tests/docker "${lxd_snap_channel}"
 
 # gpu
 # XXX: requires nvidia graphic card to be present in the host

--- a/tests/main-testflinger
+++ b/tests/main-testflinger
@@ -34,7 +34,8 @@ run_test jammy default tests/cgroup "${lxd_snap_channel}"
 #run_test jammy cgroup1 tests/cgroup "${lxd_snap_channel}"
 run_test jammy swapaccount tests/cgroup "${lxd_snap_channel}"
 run_test focal default tests/cgroup "${lxd_snap_channel}"
-run_test focal swapaccount tests/cgroup "${lxd_snap_channel}"
+# https://github.com/canonical/lxd-ci/issues/7
+#run_test focal swapaccount tests/cgroup "${lxd_snap_channel}"
 
 # cluster (upgrade from XX/stable -> ${lxd_snap_channel})
 cluster_snap_src_channel="$(echo "${lxd_snap_channel}" | cut -d/ -f1)/stable"

--- a/tests/network
+++ b/tests/network
@@ -1,16 +1,91 @@
 #!/bin/sh
 set -eux
 
-# Install dependencies
-install_deps jq
+# testflinger_queue: luma
+
+# Check if IOMMU is configured
+if [ -n "$(find /sys/kernel/iommu_groups/ -empty)" ]; then
+    echo "System not IOMMU ready, hint: \"./bin/custom-kernel iommu\"" >&2
+    exit 1
+fi
 
 # Install LXD
 install_lxd
 
-parentNIC="${1}"
+# Install dependencies
+install_deps jq
+
+parentNIC="${1:-}"
+
+if [ -z "${parentNIC}" ]; then
+  # Consult available resources
+  first_sriov_nic="$(lxc query /1.0/resources | jq -r '[.network.cards | .[] | select(.sriov != null) | .ports][0] | .[0].id')"
+  parentNIC="${first_sriov_nic}"
+fi
 
 # Enable SR-IOV on nic and bring up
 enableNICSRIOV "${parentNIC}"
+
+# Check that all instances have an IPv4 and IPv6 address
+networkTests() {
+    FAIL=0
+
+    echo "=> Performing network tests"
+    for url in $(lxc query "/1.0/instances" | jq -r .[]); do
+        name=$(echo "${url}" | cut -d/ -f4)
+        echo ""
+
+        # Get the addresses
+        address=$(lxc query "${url}/state" | jq -r ".network.eth0.addresses | .[] | select(.scope | contains(\"global\")) | .address" 2>/dev/null || true)
+        if [ -z "${address}" ]; then
+            address=$(lxc query "${url}/state" | jq -r ".network.enp5s0.addresses | .[] | select(.scope | contains(\"global\")) | .address" 2>/dev/null || true)
+        fi
+
+        if [ -z "${address}" ]; then
+            echo "FAIL: No network interface: ${name}"
+            FAIL=1
+            continue
+        fi
+
+        # IPv4 address
+        if echo "${address}" | grep -qF "."; then
+            echo "PASS: IPv4 address: ${name}"
+        else
+            echo "FAIL: IPv4 address: ${name}"
+            FAIL=1
+        fi
+
+        # IPv6 address
+        if echo "${address}" | grep -qF ":"; then
+            echo "PASS: IPv6 address: ${name}"
+        else
+            echo "WARN: IPv6 address: ${name}"
+            #FAIL=1
+        fi
+
+        # DNS resolution
+        if lxc exec "${name}" -- getent hosts archive.ubuntu.com >/dev/null 2>&1; then
+            echo "PASS: DNS resolution: ${name}"
+        else
+            echo "FAIL: DNS resolution: ${name}"
+            FAIL=1
+        fi
+
+        # TCP connectivity
+        if lxc exec "${name}" -- nc -zv archive.ubuntu.com 80 >/dev/null 2>&1; then
+            echo "PASS: TCP connectivity: ${name}"
+        else
+            echo "FAIL: TCP connectivity: ${name}"
+            FAIL=1
+        fi
+    done
+
+    if [ "${FAIL}" = "1" ]; then
+        return 1
+    fi
+
+    return 0
+}
 
 # Configure LXD
 lxc storage create default zfs
@@ -58,60 +133,6 @@ waitInstanceBooted c1-sriov
 waitInstanceBooted v1-physical
 waitInstanceBooted v1-macvlan
 waitInstanceBooted v1-sriov
-
-# Check that all instances have an IPv4 and IPv6 address
-networkTests() {
-    # shellcheck disable=SC3043
-    local FAIL=0
-
-    echo "=> Performing network tests"
-    for url in $(lxc query "/1.0/instances" | jq -r .[]); do
-        name=$(echo "${url}" | cut -d/ -f4)
-        echo ""
-
-        # Get the addresses
-        address=$(lxc query "${url}/state" | jq -r ".network.eth0.addresses | .[] | select(.scope | contains(\"global\")) | .address" 2>/dev/null || true)
-        if [ -z "${address}" ]; then
-            address=$(lxc query "${url}/state" | jq -r ".network.enp5s0.addresses | .[] | select(.scope | contains(\"global\")) | .address" 2>/dev/null || true)
-        fi
-
-        if [ -z "${address}" ]; then
-            echo "FAIL: No network interface address: ${name}"
-            FAIL=1
-            continue
-        fi
-
-        # IPv4 address
-        if echo "${address}" | grep -qF "."; then
-            echo "PASS: IPv4 address: ${name}"
-        else
-            echo "FAIL: IPv4 address: ${name}"
-            FAIL=1
-        fi
-
-        # IPv6 address
-        if echo "${address}" | grep -qF ":"; then
-            echo "PASS: IPv6 address: ${name}"
-        else
-            echo "FAIL: IPv6 address: ${name}"
-            FAIL=1
-        fi
-
-        # DNS resolution
-        if lxc exec "${name}" -- getent hosts ubuntu.com >/dev/null 2>&1 || lxc exec "${name}" -- ping -nc1 -W1 ubuntu.com >/dev/null 2>&1; then
-            echo "PASS: DNS resolution: ${name}"
-        else
-            echo "FAIL: DNS resolution: ${name}"
-            FAIL=1
-        fi
-    done
-
-    if [ "${FAIL}" = "1" ]; then
-        return 1
-    fi
-
-    return 0
-}
 
 lxc list
 networkTests

--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -627,9 +627,11 @@ ovn_forward_tests() {
     lxc network forward create ovn-virtual-network 2001:db8:1:2::1
     ovn-nbctl list load_balancer | grep -cF name | grep -xF 0
 
-    # Check load balancer cannot be created on same listen address as forward.
-    ! lxc network load-balancer create ovn-virtual-network 192.0.2.1 || false
-    ! lxc network load-balancer create ovn-virtual-network 2001:db8:1:2::1 || false
+    if hasNeededAPIExtension network_load_balancer; then
+      # Check load balancer cannot be created on same listen address as forward.
+      ! lxc network load-balancer create ovn-virtual-network 192.0.2.1 || false
+      ! lxc network load-balancer create ovn-virtual-network 2001:db8:1:2::1 || false
+    fi
 
     # Check user config is allowed, but unknown keys are not.
     lxc network forward set ovn-virtual-network 192.0.2.1 user.foo=bar
@@ -2032,7 +2034,11 @@ else
     # Otherwise run full suite.
     ovn_basic_tests
     ovn_forward_tests
-    ovn_load_balancer_tests
+    if hasNeededAPIExtension network_load_balancer; then
+      ovn_load_balancer_tests
+    else
+      echo "Skipping ovn_load_balancer_tests, not supported"
+    fi
     ovn_peering_tests
     ovn_dhcp_reservation_tests
     ovn_nested_vlan_tests

--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -2041,7 +2041,11 @@ else
     fi
     ovn_peering_tests
     ovn_dhcp_reservation_tests
-    ovn_nested_vlan_tests
+    if hasNeededAPIExtension ovn_nic_nesting; then
+      ovn_nested_vlan_tests
+    else
+      echo "Skipping ovn_nested_vlan_tests, not supported"
+    fi
     ovn_acl_tests
     ovn_l3only_tests
     ovn_leases_tests

--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -719,6 +719,7 @@ ovn_forward_tests() {
     sleep 2
 
     # Check forward is working by probing TCP/22.
+    # XXX: ping used to work but doesn't anymore due to a regression in OVN in Jammy (22.03.3-0ubuntu0.22.04.1?)
     # Relies on static route (above) rather than neighbour adverts see https://github.com/ovn-org/ovn/issues/124
     nc -zv 192.0.2.1 22
     nc -zv 2001:db8:1:2::1 22
@@ -764,6 +765,9 @@ EOF
 
     lxc network forward port add ovn-virtual-network 192.0.2.1 tcp 53 "${U2_IPV4}"
     lxc network forward port add ovn-virtual-network 2001:db8:1:2::1 tcp 53 "${U2_IPV6}"
+
+    # Allow time for forwarded port to be operational
+    sleep 2
 
     dig a +tcp @192.0.2.1 u2.lxd
     dig aaaa +tcp @2001:db8:1:2::1 u2.lxd

--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -66,6 +66,7 @@ ovn_basic_tests() {
     waitInstanceBooted u2
     waitInstanceBooted u3
     waitInstanceBooted 4u
+    sleep 2
     lxc list
 
     echo "==> Testing connectivity"

--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -2047,7 +2047,11 @@ else
       echo "Skipping ovn_nested_vlan_tests, not supported"
     fi
     ovn_acl_tests
-    ovn_l3only_tests
+    if hasNeededAPIExtension network_ovn_l3only; then
+      ovn_l3only_tests
+    else
+      echo "Skipping ovn_l3only_tests, not supported"
+    fi
     ovn_leases_tests
 fi
 

--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -716,10 +716,10 @@ ovn_forward_tests() {
     lxc network forward create ovn-virtual-network 2001:db8:1:2::1 target_address="${U1_IPV6}"
     sleep 2
 
-    # Check forward is working by pinging it.
+    # Check forward is working by probing TCP/22.
     # Relies on static route (above) rather than neighbour adverts see https://github.com/ovn-org/ovn/issues/124
-    ping -nc1 -4 -w5 192.0.2.1
-    ping -nc1 -6 -w5 2001:db8:1:2::1
+    nc -zv 192.0.2.1 22
+    nc -zv 2001:db8:1:2::1 22
 
     # Check DNS TCP forwarding using default target rule.
     lxc exec u1 -- systemctl mask dnsmasq

--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -617,9 +617,8 @@ ovn_forward_tests() {
     lxc network set lxdbr0 ipv4.routes=192.0.2.0/24 ipv6.routes=2001:db8:1:2::/64 --project=default
 
     # Add a static route to SNAT address on uplink to OVN network's router (simulating BGP route advert to uplink).
-    ovnIPv4="$(lxc network get ovn-virtual-network volatile.network.ipv4.address)"
+    # XXX: only needed for IPv6 now (see https://github.com/ovn-org/ovn/issues/124)
     ovnIPv6="$(lxc network get ovn-virtual-network volatile.network.ipv6.address)"
-    ip r add 192.0.2.1/32 via "${ovnIPv4}" dev lxdbr0
     ip r add 2001:db8:1:2::1/128 via "${ovnIPv6}" dev lxdbr0
 
     # Check forwards can be created with no target address.
@@ -838,9 +837,8 @@ ovn_load_balancer_tests() {
     lxc network set lxdbr0 ipv4.routes=192.0.2.0/24 ipv6.routes=2001:db8:1:2::/64 --project=default
 
     # Add a static route to SNAT address on uplink to OVN network's router (simulating BGP route advert to uplink).
-    ovnIPv4="$(lxc network get ovn-virtual-network volatile.network.ipv4.address)"
+    # XXX: only needed for IPv6 now (see https://github.com/ovn-org/ovn/issues/124)
     ovnIPv6="$(lxc network get ovn-virtual-network volatile.network.ipv6.address)"
-    ip r add 192.0.2.1/32 via "${ovnIPv4}" dev lxdbr0
     ip r add 2001:db8:1:2::1/128 via "${ovnIPv6}" dev lxdbr0
 
     # Check load balancers can be created.

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -32,8 +32,8 @@ do
                 lxc storage create "${poolName}" "${poolDriver}" size=20GiB
         fi
 
-        echo "==> Create VM and boot"
-        lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
+        echo "==> Create VM and boot with small root"
+        lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}" -d root,size=4GiB
         lxc start v1
         waitInstanceReady v1
         lxc info v1
@@ -56,8 +56,8 @@ do
         ! lxc exec v1 -- touch /srv/lxd-test || false
         lxc exec v1 -- umount /srv
 
-        echo "==> Checking VM root disk size is 10GiB"
-        [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "10" ]
+        echo "==> Checking VM root disk size is 4GiB"
+        [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "4" ]
 
         echo "foo" | lxc exec v1 -- tee /root/foo.txt
         lxc exec v1 -- sync
@@ -88,8 +88,8 @@ do
         waitInstanceReady v2
         lxc exec v2 -- cat /root/foo.txt | grep -Fx "foo"
 
-        echo "==> Checking VM snapshot copy root disk size is 10GiB"
-        [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "10" ]
+        echo "==> Checking VM snapshot copy root disk size is 4GiB"
+        [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "4" ]
         lxc delete -f v2
         lxc delete v1/snap0
 
@@ -293,14 +293,14 @@ do
 
         echo "==> Create VM from profile with small disk size"
         lxc profile copy default vmsmall
-        lxc profile device add vmsmall root disk pool="${poolName}" path=/ size=7GiB
+        lxc profile device add vmsmall root disk pool="${poolName}" path=/ size=3GiB
         lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -p vmsmall
         lxc start v1
         waitInstanceReady v1
         lxc info v1
 
-        echo "==> Checking VM root disk size is 7GiB"
-        [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "7" ]
+        echo "==> Checking VM root disk size is 3GiB"
+        [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "3" ]
         lxc stop -f v1
 
         echo "==> Copy to different storage pool with same driver and check size"
@@ -319,8 +319,8 @@ do
         waitInstanceReady v2
         lxc info v2
 
-        echo "==> Checking copied VM root disk size is 7GiB"
-        [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "7" ]
+        echo "==> Checking copied VM root disk size is 3GiB"
+        [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "3" ]
         lxc delete -f v2
         lxc storage delete "${poolName}2"
 
@@ -336,8 +336,8 @@ do
         waitInstanceReady v2
         lxc info v2
 
-        echo "==> Checking copied VM root disk size is 7GiB"
-        [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "7" ]
+        echo "==> Checking copied VM root disk size is 3GiB"
+        [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "3" ]
         lxc delete -f v2
 
         echo "==> Grow above default volume size and copy to different storage pool"

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -3,6 +3,9 @@ set -eux
 
 # testflinger_queue: hardhat
 
+# Install dependencies
+install_deps jq
+
 # Install LXD
 install_lxd
 

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -33,7 +33,7 @@ do
         fi
 
         echo "==> Create VM and boot"
-        lxc init "${TEST_IMG:-ubuntu-daily:22.04}" v1 --vm -s "${poolName}"
+        lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
         lxc start v1
         waitInstanceReady v1
         lxc info v1
@@ -220,7 +220,7 @@ do
         truncate -s 5m "/tmp/lxd-test-${poolName}/lxd-test-block"
 
         echo "==> Checking disk device hotplug support"
-        lxc launch "${TEST_IMG:-ubuntu-daily:22.04}" v1 --vm -s "${poolName}"
+        lxc launch "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
         waitInstanceReady v1
 
         # Hotplug disks
@@ -262,7 +262,7 @@ do
 
         echo "==> Change volume.size on pool and create VM"
         lxc storage set "${poolName}" volume.size 6GiB
-        lxc init "${TEST_IMG:-ubuntu-daily:22.04}" v1 --vm -s "${poolName}"
+        lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
         lxc start v1
         waitInstanceReady v1
         lxc info v1
@@ -277,7 +277,7 @@ do
         if [ "${poolDriver}" = "lvm" ]; then
                 echo "==> Change volume.block.filesystem on pool and create VM"
                 lxc storage set "${poolName}" volume.block.filesystem xfs
-                lxc init "${TEST_IMG:-ubuntu-daily:22.04}" v1 --vm -s "${poolName}"
+                lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
                 lxc start v1
                 waitInstanceReady v1
                 lxc info v1
@@ -294,7 +294,7 @@ do
         echo "==> Create VM from profile with small disk size"
         lxc profile copy default vmsmall
         lxc profile device add vmsmall root disk pool="${poolName}" path=/ size=7GiB
-        lxc init "${TEST_IMG:-ubuntu-daily:22.04}" v1 --vm -p vmsmall
+        lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -p vmsmall
         lxc start v1
         waitInstanceReady v1
         lxc info v1
@@ -384,7 +384,7 @@ do
         lxc profile delete vmsmall
 
         echo "==> Checking VM Generation UUID with QEMU"
-        lxc init "${TEST_IMG:-ubuntu-daily:22.04}" v1 --vm -s "${poolName}"
+        lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
         lxc start v1
         waitInstanceReady v1
         lxc info v1

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eux
 
+# testflinger_queue: hardhat
+
 # Install LXD
 install_lxd
 

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -9,7 +9,8 @@ install_deps jq
 # Install LXD
 install_lxd
 
-poolDriverList="${1:-dir btrfs lvm lvm-thin zfs ceph}"
+# XXX: skip ceph for now
+poolDriverList="${1:-dir btrfs lvm lvm-thin zfs}"
 
 # Configure LXD
 lxc network create lxdbr0

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -2,7 +2,9 @@
 set -eux
 
 # Install dependencies
-install_deps genisoimage
+if hasNeededAPIExtension custom_volume_iso; then
+  install_deps genisoimage
+fi
 
 # Install LXD
 install_lxd
@@ -66,17 +68,21 @@ do
 	rm vol1.tar.gz
 	rm vol1-optimized.tar.gz
 
-	echo "==> Import custom ISO volume"
-	tmp_iso_dir="$(mktemp -d)"
-	echo foo > "${tmp_iso_dir}/foo"
-	genisoimage -o vol5.iso "${tmp_iso_dir}"
-	rm -f "${tmp_iso_dir}/foo"
-	echo bar > "${tmp_iso_dir}/bar"
-	genisoimage -o vol6.iso "${tmp_iso_dir}"
-	rm -rf "${tmp_iso_dir}"
-	lxc storage volume import "${poolName}" vol5.iso vol5
-	lxc storage volume import "${poolName}" vol6.iso vol6
-	rm -f vol5.iso vol6.iso
+    if hasNeededAPIExtension custom_volume_iso; then
+	  echo "==> Import custom ISO volume"
+	  tmp_iso_dir="$(mktemp -d)"
+	  echo foo > "${tmp_iso_dir}/foo"
+	  genisoimage -o vol5.iso "${tmp_iso_dir}"
+	  rm -f "${tmp_iso_dir}/foo"
+	  echo bar > "${tmp_iso_dir}/bar"
+	  genisoimage -o vol6.iso "${tmp_iso_dir}"
+	  rm -rf "${tmp_iso_dir}"
+	  lxc storage volume import "${poolName}" vol5.iso vol5
+	  lxc storage volume import "${poolName}" vol6.iso vol6
+	  rm -f vol5.iso vol6.iso
+    else
+	  echo "==> Skipping custom ISO volume tests, not supported"
+    fi
 
 	echo "==> Attach custom block volumes to VM"
 	# Both volumes can be attached at the same time. The VM will have /dev/sdb and /dev/sdc.
@@ -84,11 +90,15 @@ do
 	lxc storage volume attach "${poolName}" vol2 v1
 	lxc storage volume attach "${poolName}" vol3 v1
 
-	echo "==> Attach custom ISO volumes to VM"
-	lxc storage volume attach "${poolName}" vol5 v1
-	lxc storage volume attach "${poolName}" vol6 v1
-	lxc storage volume attach "${poolName}" vol5 v2
-	lxc storage volume attach "${poolName}" vol6 v2
+    if hasNeededAPIExtension custom_volume_iso; then
+	  echo "==> Attach custom ISO volumes to VM"
+	  lxc storage volume attach "${poolName}" vol5 v1
+	  lxc storage volume attach "${poolName}" vol6 v1
+	  lxc storage volume attach "${poolName}" vol5 v2
+	  lxc storage volume attach "${poolName}" vol6 v2
+    else
+	  echo "==> Skipping custom ISO volume tests, not supported"
+    fi
 
 	echo "==> Start VM and check content"
 	lxc start v1
@@ -101,19 +111,23 @@ do
 	# shellcheck disable=2016
 	lxc exec v1 -- /bin/sh -c 'mount /dev/sdc /mnt && [ $(cat /mnt/bar) = foo ] && umount /mnt'
 
-	# mount ISOs and check content
-	# shellcheck disable=2016
-	lxc exec v1 -- /bin/sh -c 'mount /dev/sr0 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo && umount /mnt'
-	# shellcheck disable=2016
-	lxc exec v1 -- /bin/sh -c 'mount /dev/sr1 /mnt && [ $(cat /mnt/bar) = bar ] && ! touch /mnt/bar && umount /mnt'
+    if hasNeededAPIExtension custom_volume_iso; then
+	  # mount ISOs and check content
+	  # shellcheck disable=2016
+	  lxc exec v1 -- /bin/sh -c 'mount /dev/sr0 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo && umount /mnt'
+	  # shellcheck disable=2016
+	  lxc exec v1 -- /bin/sh -c 'mount /dev/sr1 /mnt && [ $(cat /mnt/bar) = bar ] && ! touch /mnt/bar && umount /mnt'
 
-	# concurrent readonly ISO mounts
-	# shellcheck disable=2016
-	lxc exec v1 -- /bin/sh -c 'mount /dev/sr0 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo'
-	# shellcheck disable=2016
-	lxc exec v2 -- /bin/sh -c 'mount /dev/sr0 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo'
-	lxc exec v1 -- umount /mnt
-	lxc exec v2 -- umount /mnt
+	  # concurrent readonly ISO mounts
+	  # shellcheck disable=2016
+	  lxc exec v1 -- /bin/sh -c 'mount /dev/sr0 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo'
+	  # shellcheck disable=2016
+	  lxc exec v2 -- /bin/sh -c 'mount /dev/sr0 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo'
+	  lxc exec v1 -- umount /mnt
+	  lxc exec v2 -- umount /mnt
+    else
+	  echo "==> Skipping custom ISO volume tests, not supported"
+    fi
 
 	echo "==> Detaching volumes"
 	lxc exec v1 -- "sync"
@@ -121,7 +135,7 @@ do
 	lxc delete -f v2
 	lxc storage volume detach "${poolName}" vol2 v1
 	lxc storage volume detach "${poolName}" vol3 v1
-	lxc storage volume detach "${poolName}" vol6 v1
+	lxc storage volume detach "${poolName}" vol6 v1 || true  # optional ISO
 
 	echo "==> Publishing VM to image"
 	lxc storage volume create "${poolName}" images --project=default
@@ -142,8 +156,8 @@ do
 	lxc storage volume rm "${poolName}" vol2
 	lxc storage volume rm "${poolName}" vol3
 	lxc storage volume rm "${poolName}" vol4
-	lxc storage volume rm "${poolName}" vol5
-	lxc storage volume rm "${poolName}" vol6
+	lxc storage volume rm "${poolName}" vol5 || true  # optional ISO
+	lxc storage volume rm "${poolName}" vol6 || true  # optional ISO
 	lxc storage rm "${poolName}"
 done
 

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -36,8 +36,8 @@ do
 	fi
 
 	echo "==> Create VM"
-	lxc init "${TEST_IMG:-ubuntu-daily:22.04}" v1 --vm -s "${poolName}"
-	lxc init "${TEST_IMG:-ubuntu-daily:22.04}" v2 --vm -s "${poolName}"
+	lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
+	lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v2 --vm -s "${poolName}"
 
 	echo "==> Create custom block volume and attach it to VM"
 	lxc storage volume create "${poolName}" vol1 --type=block size=10MB

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -9,7 +9,8 @@ fi
 # Install LXD
 install_lxd
 
-poolDriverList="${1:-dir btrfs lvm lvm-thin zfs ceph}"
+# XXX: skip ceph for now
+poolDriverList="${1:-dir btrfs lvm lvm-thin zfs}"
 
 # Configure LXD
 lxc project switch default

--- a/tests/vm-nesting
+++ b/tests/vm-nesting
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eux
 
+# testflinger_queue: ficet
+
 # Install LXD.
 install_lxd
 


### PR DESCRIPTION
Many small fixes with the most interesting parts being in `tests/network-ovn` where the workaround for 
https://github.com/ovn-org/ovn/issues/124 was updated to be IPv6 only (IPv4 now works). For some reason, ICMP doesn't go through but TCP does which seems in line with that `ovn-nbctl` reports:

```
# lxc network forward create ovn-virtual-network 192.0.2.1 target_address=10.105.175.2
Network forward 192.0.2.1 created

# ovn-nbctl list load_balancer
_uuid               : 2610499d-ca24-4ddc-bb3e-d710cb572621
external_ids        : {}
health_check        : []
ip_port_mappings    : {}
name                : lxd-net22-lb-192.0.2.1-tcp
options             : {}
protocol            : tcp
selection_fields    : []
vips                : {"192.0.2.1"="10.105.175.2"}
```

Is this an OVN regression or simply that LXD doesn't provided the needed protocol list?

Of note, the `tests/docker` script was changed to not depend on the Docker Hub that was preventing tests from Canonical IP space due to high image fetch running into a limit. It now uses a locally built hello-world using busybox.

Anyway, with those changes, only those tests fail with `5.0/candidate`:

1. `tests/storage-vm` fails with `ceph` (temporarily disabled, see https://github.com/canonical/lxd-ci/issues/59)
2. `tests/storage-volumes-vm` fails with `ceph` (temporarily disabled, see https://github.com/canonical/lxd-ci/issues/59)
3.  `tests/cgroup` but only with `focal` and `swapaccount` but that's not new as it was also the case in https://github.com/canonical/lxd-ci/issues/7#issuecomment-1850832334

All the tests were done on amd64:

```
# snap list lxd
Name  Version        Rev    Tracking       Publisher   Notes
lxd   5.0.3-974ce5c  26838  5.0/candidate  canonical✓  -
```