### PR TITLE
Adapt VM storage tests to support Dell PowerFlex

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Or to run individual tests (`tests/pylxd` against `latest/edge`):
 ./bin/openstack-run jammy default tests/pylxd latest/edge
 ```
 
+# Running Dell PowerFlex VM storage tests
+
+To run the VM storage tests on the Dell PowerFlex driver, provide the following environment variables:
+
+* `POWERFLEX_POOL`: Name of the PowerFlex storage pool
+* `POWERFLEX_DOMAIN`: Name of the PowerFlex domain
+* `POWERFLEX_GATEWAY`: Address of the PowerFlex HTTP gateway
+* `POWERFLEX_GATEWAY_VERIFY`: Whether to verify the HTTP gateway's certificate. The default is `true`.
+* `POWERFLEX_USER`: Name of the PowerFlex user
+* `POWERFLEX_PASSWORD`: Password of the PowerFlex user
+
 # Infrastructure managed by IS
 
 The PS6 environment has inbound and outbound firewalling applied at the network edge. In order to access some external sites here are the firewall rules we added to firewall maintained by IS:

--- a/bin/helpers
+++ b/bin/helpers
@@ -154,6 +154,17 @@ runsMinimumKernel() (
     return 0
 )
 
+# createPowerFlexPool: creates a new storage pool using the PowerFlex driver.
+createPowerFlexPool() (
+  lxc storage create "${1}" powerflex \
+    powerflex.pool="${POWERFLEX_POOL}" \
+    powerflex.domain="${POWERFLEX_DOMAIN}" \
+    powerflex.gateway="${POWERFLEX_GATEWAY}" \
+    powerflex.gateway.verify="${POWERFLEX_GATEWAY_VERIFY:-true}" \
+    powerflex.user.name="${POWERFLEX_USER}" \
+    powerflex.user.password="${POWERFLEX_PASSWORD}"
+)
+
 # cleanup: report if the test passed or not and return the appropriate return code.
 cleanup() {
     set +e

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -29,12 +29,18 @@ do
                 lxc storage create "${poolName}" "${poolDriver}" size=60GiB lvm.use_thinpool=false
         elif [ "${poolDriver}" = "lvm-thin" ]; then
                 lxc storage create "${poolName}" lvm size=20GiB
+        elif [ "${poolDriver}" = "powerflex" ]; then
+                createPowerFlexPool "${poolName}"
         else
                 lxc storage create "${poolName}" "${poolDriver}" size=20GiB
         fi
 
         echo "==> Create VM and boot with small root"
-        lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}" -d root,size=4GiB
+        if [ "${poolDriver}" != "powerflex" ]; then
+                lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}" -d root,size=4GiB
+        else
+                lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}" -d root,size=8GiB
+        fi
         lxc start v1
         waitInstanceReady v1
         lxc info v1
@@ -57,8 +63,13 @@ do
         ! lxc exec v1 -- touch /srv/lxd-test || false
         lxc exec v1 -- umount /srv
 
-        echo "==> Checking VM root disk size is 4GiB"
-        [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "4" ]
+        if [ "${poolDriver}" != "powerflex" ]; then
+                echo "==> Checking VM root disk size is 4GiB"
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "4" ]
+        else
+                echo "==> Checking VM root disk size is 8GiB"
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+        fi
 
         echo "foo" | lxc exec v1 -- tee /root/foo.txt
         lxc exec v1 -- sync
@@ -89,8 +100,13 @@ do
         waitInstanceReady v2
         lxc exec v2 -- cat /root/foo.txt | grep -Fx "foo"
 
-        echo "==> Checking VM snapshot copy root disk size is 4GiB"
-        [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "4" ]
+        if [ "${poolDriver}" != "powerflex" ]; then
+                echo "==> Checking VM snapshot copy root disk size is 4GiB"
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "4" ]
+        else
+                echo "==> Checking VM snapshot copy root disk size is 8GiB"
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+        fi
         lxc delete -f v2
         lxc delete v1/snap0
 
@@ -129,14 +145,23 @@ do
         waitInstanceReady v1
 
         echo "==> Increasing VM root disk size for next boot"
-        lxc config device set v1 root size=11GiB
+        if [ "${poolDriver}" != "powerflex" ]; then
+                lxc config device set v1 root size=11GiB
+        else
+                lxc config device set v1 root size=16GiB
+        fi
         lxc config get v1 volatile.root.apply_quota | grep true
         lxc stop -f v1
         lxc start v1
         waitInstanceReady v1
 
-        echo "==> Checking VM root disk size is 11GiB"
-        [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "11" ]
+        if [ "${poolDriver}" != "powerflex" ]; then
+                echo "==> Checking VM root disk size is 11GiB"
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "11" ]
+        else
+                echo "==> Checking VM root disk size is 16GiB"
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "16" ]
+        fi
 
         echo "==> Check VM shrink is blocked"
         ! lxc config device set v1 root size=10GiB || false
@@ -225,7 +250,11 @@ do
         waitInstanceReady v1
 
         # Hotplug disks
-        lxc storage volume create "${poolName}" vol1 --type=block size=10MB
+        if [ "${poolDriver}" != "powerflex" ]; then
+                lxc storage volume create "${poolName}" vol1 --type=block size=10MB
+        else
+                lxc storage volume create "${poolName}" vol1 --type=block size=8GiB
+        fi
         lxc storage volume attach "${poolName}" vol1 v1
         sleep 3
         lxc exec v1 -- stat -c "%F" /dev/sdb | grep "block special file"
@@ -262,14 +291,24 @@ do
         lxc delete -f v1
 
         echo "==> Change volume.size on pool and create VM"
-        lxc storage set "${poolName}" volume.size 6GiB
+        if [ "${poolDriver}" != "powerflex" ]; then
+                lxc storage set "${poolName}" volume.size 6GiB
+        else
+                # Set to something else than the default of 8GiB.
+                lxc storage set "${poolName}" volume.size 16GiB
+        fi
         lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
         lxc start v1
         waitInstanceReady v1
         lxc info v1
 
-        echo "==> Checking VM root disk size is 6GiB"
-        [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "6" ]
+        if [ "${poolDriver}" != "powerflex" ]; then
+                echo "==> Checking VM root disk size is 6GiB"
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "6" ]
+        else
+                echo "==> Checking VM root disk size is 16GiB"
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "16" ]
+        fi
 
         echo "==> Deleting VM and reset pool volume.size"
         lxc delete -f v1
@@ -294,14 +333,23 @@ do
 
         echo "==> Create VM from profile with small disk size"
         lxc profile copy default vmsmall
-        lxc profile device add vmsmall root disk pool="${poolName}" path=/ size=3GiB
+        if [ "${poolDriver}" != "powerflex" ]; then
+                lxc profile device add vmsmall root disk pool="${poolName}" path=/ size=3GiB
+        else
+                lxc profile device add vmsmall root disk pool="${poolName}" path=/ size=8GiB
+        fi
         lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -p vmsmall
         lxc start v1
         waitInstanceReady v1
         lxc info v1
 
-        echo "==> Checking VM root disk size is 3GiB"
-        [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "3" ]
+        if [ "${poolDriver}" != "powerflex" ]; then
+                echo "==> Checking VM root disk size is 3GiB"
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "3" ]
+        else
+                echo "==> Checking VM root disk size is 8GiB"
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+        fi
         lxc stop -f v1
 
         echo "==> Copy to different storage pool with same driver and check size"
@@ -311,6 +359,8 @@ do
                 lxc storage create "${poolName}2" "${poolDriver}" size=40GiB lvm.use_thinpool=false
         elif [ "${poolDriver}" = "lvm-thin" ]; then
                 lxc storage create "${poolName}2" lvm size=20GiB
+        elif [ "${poolDriver}" = "powerflex" ]; then
+                createPowerFlexPool "${poolName}2"
         else
                 lxc storage create "${poolName}2" "${poolDriver}" size=20GiB
         fi
@@ -320,8 +370,13 @@ do
         waitInstanceReady v2
         lxc info v2
 
-        echo "==> Checking copied VM root disk size is 3GiB"
-        [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "3" ]
+        if [ "${poolDriver}" != "powerflex" ]; then
+                echo "==> Checking copied VM root disk size is 3GiB"
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "3" ]
+        else
+                echo "==> Checking copied VM root disk size is 8GiB"
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+        fi
         lxc delete -f v2
         lxc storage delete "${poolName}2"
 
@@ -337,19 +392,33 @@ do
         waitInstanceReady v2
         lxc info v2
 
-        echo "==> Checking copied VM root disk size is 3GiB"
-        [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "3" ]
+        if [ "${poolDriver}" != "powerflex" ]; then
+                echo "==> Checking copied VM root disk size is 3GiB"
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "3" ]
+        else
+                echo "==> Checking copied VM root disk size is 8GiB"
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+        fi
         lxc delete -f v2
 
         echo "==> Grow above default volume size and copy to different storage pool"
-        lxc config device override v1 root size=11GiB
+        if [ "${poolDriver}" != "powerflex" ]; then
+                lxc config device override v1 root size=11GiB
+        else
+                lxc config device override v1 root size=16GiB
+        fi
         lxc copy v1 v2 -s "${poolName}2"
         lxc start v2
         waitInstanceReady v2
         lxc info v2
 
-        echo "==> Checking copied VM root disk size is 11GiB"
-        [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "11" ]
+        if [ "${poolDriver}" != "powerflex" ]; then
+                echo "==> Checking copied VM root disk size is 11GiB"
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "11" ]
+        else
+                echo "==> Checking copied VM root disk size is 16GiB"
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "16" ]
+        fi
         lxc delete -f v2
         lxc storage delete "${poolName}2"
 
@@ -360,7 +429,11 @@ do
         lxc stop -f v1
         lxc publish v1 --alias vmbig
         lxc delete -f v1
-        lxc storage set "${poolName}" volume.size 9GiB
+        if [ "${poolDriver}" != "powerflex" ]; then
+                lxc storage set "${poolName}" volume.size 9GiB
+        else
+                lxc storage set "${poolName}" volume.size 8GiB
+        fi
 
         echo "==> Check VM create fails when image larger than volume.size"
         ! lxc init vmbig v1 --vm -s "${poolName}" || false
@@ -372,8 +445,13 @@ do
         waitInstanceReady v1
         lxc info v1
 
-        echo "==> Checking new VM root disk size is 11GiB"
-        [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "11" ]
+        if [ "${poolDriver}" != "powerflex" ]; then
+                echo "==> Checking new VM root disk size is 11GiB"
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "11" ]
+        else
+                echo "==> Checking new VM root disk size is 16GiB"
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "16" ]
+        fi
 
         echo "===> Renaming VM"
         lxc stop -f v1

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -32,6 +32,8 @@ do
                 lxc storage create "${poolName}" "${poolDriver}" size=40GiB lvm.use_thinpool=false volume.size=5GB
         elif [ "${poolDriver}" = "lvm-thin" ]; then
                 lxc storage create "${poolName}" lvm size=20GiB volume.size=5GB
+	elif [ "${poolDriver}" = "powerflex" ]; then
+		createPowerFlexPool "${poolName}"
 	else
 		lxc storage create "${poolName}" "${poolDriver}" size=20GB volume.size=5GB
 	fi
@@ -41,11 +43,19 @@ do
 	lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v2 --vm -s "${poolName}"
 
 	echo "==> Create custom block volume and attach it to VM"
-	lxc storage volume create "${poolName}" vol1 --type=block size=10MB
+	if [ "${poolDriver}" != "powerflex" ]; then
+		lxc storage volume create "${poolName}" vol1 --type=block size=10MB
+	else
+		lxc storage volume create "${poolName}" vol1 --type=block size=8GiB
+	fi
 	lxc storage volume attach "${poolName}" vol1 v1
 
 	echo "==> Create custom volume and attach it to VM"
-	lxc storage volume create "${poolName}" vol4 size=10MB
+	if [ "${poolDriver}" != "powerflex" ]; then
+		lxc storage volume create "${poolName}" vol4 size=10MB
+	else
+		lxc storage volume create "${poolName}" vol4 size=8GiB
+	fi
 	lxc storage volume attach "${poolName}" vol4 v1 /foo
 
 	echo "==> Start VM and add content to custom block volume"


### PR DESCRIPTION
This PR adapts both of the VM storage tests so they can be executed using the Dell PowerFlex storage driver from https://github.com/canonical/lxd/pull/12304.

Storage size values for PowerFlex need to be in multiples of 8GiB. The minimal storage volume size in PowerFlex is also 8GiB. 
Where applicable the storage size of the actual test was increased for all the drivers to accommodate PowerFlex. At other places a different storage size gets set for the PowerFlex driver only.