### PR TITLE
tests/storage-volumes-vm: always install genisoimage

### DIFF
--- a/bin/openstack-run
+++ b/bin/openstack-run
@@ -54,6 +54,7 @@ create() {
     openstack server create --key-name "${KEY_NAME}" --flavor "${FLAVOR}" --network "${NETWORK}" --image "${IMAGE}" --user-data ./cloud-init.user-data.yaml --wait "${NAME}"
     IP="$(openstack server show -f value -c addresses "${NAME}" | cut -d\' -f4)"
     [ "${IP}" != "{}" ]
+    [ -n "${IP}" ]
     echo "${NAME}: ${IP}" >&2
 }
 

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -2,9 +2,7 @@
 set -eux
 
 # Install dependencies
-if hasNeededAPIExtension custom_volume_iso; then
-  install_deps genisoimage
-fi
+install_deps genisoimage
 
 # Install LXD
 install_lxd


### PR DESCRIPTION
`hasNeededAPIExtension` checks the LXD extension list so using it prior to `install_lxd` will not work reliably. This package being ~370KiB, let's just always install it.