### PR TITLE
Improve `custom-kernel`

### DIFF
--- a/bin/custom-kernel
+++ b/bin/custom-kernel
@@ -162,6 +162,11 @@ case "$i" in
           exit 1
         fi
 
+        if mokutil --sb-state | grep -Fx "SecureBoot enabled"; then
+          echo "Daily kernels are unsigned so incompatible with SecureBoot"
+          exit 1
+        fi
+
         wget -e robots=off -r --no-parent -A '*all*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/amd64/
         wget -e robots=off -r --no-parent -A '*amd64*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/amd64/
         echo "MODULES=dep" > /etc/initramfs-tools/conf.d/modules.conf

--- a/bin/custom-kernel
+++ b/bin/custom-kernel
@@ -165,9 +165,7 @@ case "$i" in
         wget -e robots=off -r --no-parent -A '*all*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/amd64/
         wget -e robots=off -r --no-parent -A '*amd64*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/amd64/
         echo "MODULES=dep" > /etc/initramfs-tools/conf.d/modules.conf
-        apt-get update
-        apt-get install ./kernel.ubuntu.com/mainline/daily/current/amd64/*.deb --yes
-        apt-get dist-upgrade --yes
+        dpkg --force-depends -i ./kernel.ubuntu.com/mainline/daily/current/amd64/*.deb
       ;;
 
       *)

--- a/bin/custom-kernel
+++ b/bin/custom-kernel
@@ -173,4 +173,5 @@ case "$i" in
     esac
 done
 
+update-grub
 reboot

--- a/bin/custom-kernel
+++ b/bin/custom-kernel
@@ -173,11 +173,4 @@ case "$i" in
     esac
 done
 
-# Since we are doing a reboot, might as well also turn off mitigations and have a faster testbed
-echo "===> Disabling all mitigations"
-
-# shellcheck disable=SC2016
-echo 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} mitigations=off"' > /etc/default/grub.d/99-mitigations.cfg
-update-grub
-
 reboot

--- a/bin/custom-kernel
+++ b/bin/custom-kernel
@@ -162,8 +162,8 @@ case "$i" in
           exit 1
         fi
 
-        wget -e robots=off -r --no-parent -A '*all*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/
-        wget -e robots=off -r --no-parent -A '*amd64*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/
+        wget -e robots=off -r --no-parent -A '*all*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/amd64/
+        wget -e robots=off -r --no-parent -A '*amd64*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/amd64/
         echo "MODULES=dep" > /etc/initramfs-tools/conf.d/modules.conf
         apt-get update
         apt-get install ./kernel.ubuntu.com/mainline/daily/current/amd64/*.deb --yes

--- a/bin/custom-kernel
+++ b/bin/custom-kernel
@@ -157,6 +157,10 @@ case "$i" in
 
       daily)
         echo "===> Installing a mainline daily build"
+        if [ "$(uname -m)" != "x86_64" ]; then
+          echo "Unsupported architecture requested: $(uname -m)"
+          exit 1
+        fi
 
         wget -e robots=off -r --no-parent -A '*all*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/
         wget -e robots=off -r --no-parent -A '*amd64*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/

--- a/bin/custom-kernel
+++ b/bin/custom-kernel
@@ -158,11 +158,11 @@ case "$i" in
       daily)
         echo "===> Installing a mainline daily build"
 
-        wget -e robots=off -r --no-parent -A '*all*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/~kernel-ppa/mainline/daily/current/
-        wget -e robots=off -r --no-parent -A '*amd64*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/~kernel-ppa/mainline/daily/current/
+        wget -e robots=off -r --no-parent -A '*all*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/
+        wget -e robots=off -r --no-parent -A '*amd64*.deb' -R '*lpae*' -R '*lowlatency*' https://kernel.ubuntu.com/mainline/daily/current/
         echo "MODULES=dep" > /etc/initramfs-tools/conf.d/modules.conf
         apt-get update
-        apt-get install ./kernel.ubuntu.com/~kernel-ppa/mainline/daily/current/amd64/*.deb --yes
+        apt-get install ./kernel.ubuntu.com/mainline/daily/current/amd64/*.deb --yes
         apt-get dist-upgrade --yes
       ;;
 


### PR DESCRIPTION
```
root@v1:~/lxd-ci# ./bin/custom-kernel daily
===> Installing a mainline daily build
...
Generating grub configuration file ...
GRUB_FORCE_PARTUUID is set, will attempt initrdless boot
Found linux image: /boot/vmlinuz-6.8.0-060800rc5daily20240221-generic
Found initrd image: /boot/initrd.img-6.8.0-060800rc5daily20240221-generic
Found linux image: /boot/vmlinuz-5.15.0-1049-kvm
Found initrd image: /boot/initrd.img-5.15.0-1049-kvm
Warning: os-prober will not be executed to detect other bootable partitions.
Systems on them will not be added to the GRUB boot configuration.
Check GRUB_DISABLE_OS_PROBER documentation entry.
Adding boot menu entry for UEFI Firmware Settings ...
done
root@v1:~/lxd-ci# 
Session terminated, killing shell...
 ...killed.
```

Then after the reboot we have the latest kernel:

```
$ lxc shell v1
root@v1:~# uname -a
Linux v1 6.8.0-060800rc5daily20240221-generic #202402210202 SMP PREEMPT_DYNAMIC Wed Feb 21 02:14:40 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```