### PR TITLE
Small improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,7 +108,8 @@ jobs:
           # disable dpkg from calling sync()
           echo "force-unsafe-io" | sudo tee /etc/dpkg/dpkg.cfg.d/force-unsafe-io
 
-      - name: Reclaim some space
+      - name: Reclaim some space (storage tests only)
+        if: ${{ startsWith(matrix.test, 'storage') }}
         run: |
           set -eux
           df -h

--- a/bin/helpers
+++ b/bin/helpers
@@ -167,6 +167,12 @@ createPowerFlexPool() (
 
 # cleanup: report if the test passed or not and return the appropriate return code.
 cleanup() {
+    # Run any extra cleanup function
+    if command -v extra_cleanup > /dev/null; then
+      trap
+      extra_cleanup
+    fi
+
     set +e
     echo ""
     if [ "${FAIL}" = "1" ]; then
@@ -186,11 +192,6 @@ cleanup() {
         echo "::endgroup::"
 
         exit 1
-    fi
-
-    # Run any extra cleanup function only on success
-    if command -v extra_cleanup > /dev/null; then
-      extra_cleanup || true
     fi
 
     echo "Test passed"

--- a/tests/cluster
+++ b/tests/cluster
@@ -68,7 +68,7 @@ for i in $(seq "${SIZE}"); do
         MEMBER_IP=$(lxc exec "${PREFIX}-$i" -- ip -4 addr show dev eth0 scope global | grep inet | cut -d' ' -f6 | cut -d/ -f1)
 
         # Get a join token
-        TOKEN="$(lxc exec "${PREFIX}-1" -- lxc cluster add "${PREFIX}-${i}" | tail -n1)"
+        TOKEN="$(lxc exec "${PREFIX}-1" -- lxc cluster add --quiet "${PREFIX}-${i}")"
 
         lxc exec "${PREFIX}-$i" -- lxd init --preseed << EOF
 cluster:


### PR DESCRIPTION
* use `--quiet` when getting a cluster join token instead of discarding the first line of text
* `extra_cleanup()` now always execute and will halt on error behavior as we want to make sure cleanup steps do work
* only do the "reclaim space" step for storage tests.

The "reclaim space" step can take anywhere between 10s to ~2m depending if we get a fast or slow GHA runner. We only need the extra space for the `tests/storage-*` script so only run it then.