### PR TITLE
Remove more container runtimes from GitHub runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
           # optimize ext4 FSes for performance, not reliability
           for fs in $(findmnt --noheading --type ext4 --list --uniq | awk '{print $1}'); do
             # nombcache and data=writeback cannot be changed on remount
-            sudo mount -o remount,noatime,barrier=0,commit=6000 "${fs}"
+            sudo mount -o remount,noatime,barrier=0,commit=6000 "${fs}" || cat /proc/self/mountinfo
           done
 
           # disable dpkg from calling sync()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Remove docker
         run: |
           set -eux
-          sudo apt-get autopurge -y moby-containerd docker uidmap
+          sudo apt-get autopurge -y containerd.io moby-containerd docker docker-ce podman uidmap
           sudo ip link delete docker0
           sudo nft flush ruleset
 


### PR DESCRIPTION
This fixes the some rare occurrences of:

```
++ findmnt --noheading --type ext4 --list --uniq
++ awk '{print $1}'
+ for fs in $(findmnt --noheading --type ext4 --list --uniq | awk '{print $1}')
+ sudo mount -o remount,noatime,barrier=0,commit=6000 /
+ for fs in $(findmnt --noheading --type ext4 --list --uniq | awk '{print $1}')
+ sudo mount -o remount,noatime,barrier=0,commit=6000 /mnt
+ for fs in $(findmnt --noheading --type ext4 --list --uniq | awk '{print $1}')
+ sudo mount -o remount,noatime,barrier=0,commit=6000 /var/lib/containers/storage/overlay
mount: /var/lib/containers/storage/overlay: mount point not mounted or bad option.
```