### PR TITLE
tests/storage-vm: if `instances.migration.stateful=false` do not change `migration.stateful`

### DIFF
--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -514,6 +514,7 @@ for poolDriver in $poolDriverList; do
                 lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -p stateful_profile -s "${poolName}"
                 lxc query /1.0/instances/v1 | jq -r '.expanded_config["migration.stateful"]' | grep -xF true # the profile config should take precedence
                 lxc delete v1 -f
+                lxc profile delete stateful_profile
 
                 # Finally, unset the value to avoid any potential side effects on other tests.
                 lxc config unset instances.migration.stateful

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -500,7 +500,7 @@ for poolDriver in $poolDriverList; do
                 lxc delete v1 -f
                 lxc config set instances.migration.stateful=false
                 lxc init "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
-                lxc query /1.0/instances/v1 | jq -r '.expanded_config["migration.stateful"]' | grep -xF false
+                [ -z "$(lxc config get --expanded v1 migration.stateful)" ] # instances.migration.stateful leave it unset because since it is `false`, it is the same as the default value of `migration.stateful`.
                 lxc delete v1 -f
 
                 lxc config set instances.migration.stateful=true


### PR DESCRIPTION
In case of `instances.migration.stateful=false`, since `migration.stateful` is `false` by default if nothing is manually set for an instance, no need to make `migration.stateful=false` appear in the configuration. It is unset instead, which means the same.