### PR TITLE
Configurable snap tracks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,7 @@ jobs:
           - cpu-vm
           - devlxd-vm
           - docker
+          - efi-vars-editor-vm
           - interception
           - pylxd
           - network-bridge-firewall
@@ -89,11 +90,10 @@ jobs:
           - "storage-vm zfs"
           - storage-volumes-vm
           - vm-nesting
-          - efi-vars-editor-vm
         exclude:
-          - test: interception # not compatible with 5.0/* and no API extension advertised
-            track: "5.0/edge"
           - test: efi-vars-editor-vm # not compatible with 5.0/*
+            track: "5.0/edge"
+          - test: interception # not compatible with 5.0/* and no API extension advertised
             track: "5.0/edge"
           - test: storage-buckets  # waiting for integration with microceph
           - test: "storage-vm ceph" # waiting for integration with microceph

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,8 +93,6 @@ jobs:
         exclude:
           - test: efi-vars-editor-vm # not compatible with 5.0/*
             track: "5.0/edge"
-          - test: interception # not compatible with 5.0/* and no API extension advertised
-            track: "5.0/edge"
           - test: storage-buckets  # waiting for integration with microceph
           - test: "storage-vm ceph" # waiting for integration with microceph
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
     - cron:  '38 9 * * *'
   workflow_dispatch:
     inputs:
+      snap-tracks:
+        description: List of snap tracks to run the tests. In JSON format, i.e. '["latest/stable", "5.0/candidate"]'.
+        type: string
+        default: '["latest/edge"]'
       self-hosted-runner:
         type: boolean
         description: Whether to use self-hosted runners to run the jobs.
@@ -62,9 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        track:
-          - "latest/edge"
-          - "5.0/edge"
+        track: ${{ fromJSON(inputs.snap-tracks || '["latest/edge", "5.0/edge"]') }}
         test:
           - cgroup
           - cluster

--- a/tests/interception
+++ b/tests/interception
@@ -14,7 +14,7 @@ lxd init --auto
 # Test
 set -x
 
-lxc launch "${TEST_IMG:-ubuntu-daily:22.04}" c1
+lxc launch "${TEST_IMG:-ubuntu-minimal-daily:22.04}" c1
 sleep 10
 lxc exec c1 -- apt-get update
 lxc exec c1 -- apt-get install --no-install-recommends --yes attr fuse2fs

--- a/tests/interception
+++ b/tests/interception
@@ -49,45 +49,41 @@ else
     echo "Skipping security.syscalls.intercept.bpf config as the kernel is too old"
 fi
 
-if hasNeededAPIExtension container_syscall_intercept_mount; then
-    ## mount
-    truncate -s 10G loop.img
-    LOOP=$(losetup -f --show loop.img)
-    lxc config device add c1 loop unix-block source="${LOOP}" path=/dev/sda
-    lxc exec c1 -- mkfs.ext4 -F /dev/sda
-    ! lxc exec c1 -- mount /dev/sda /mnt || false
-    lxc config set c1 security.syscalls.intercept.mount=true
+## mount
+truncate -s 10G loop.img
+LOOP=$(losetup -f --show loop.img)
+lxc config device add c1 loop unix-block source="${LOOP}" path=/dev/sda
+lxc exec c1 -- mkfs.ext4 -F /dev/sda
+! lxc exec c1 -- mount /dev/sda /mnt || false
+lxc config set c1 security.syscalls.intercept.mount=true
 
-    lxc config set c1 security.syscalls.intercept.mount.allowed=ext4
+lxc config set c1 security.syscalls.intercept.mount.allowed=ext4
+lxc restart c1 -f
+lxc exec c1 -- mount /dev/sda /mnt
+[ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "65534:65534" ]
+lxc exec c1 -- umount /mnt
+
+lxc config set c1 security.syscalls.intercept.mount.shift=true
+lxc exec c1 -- mount /dev/sda /mnt
+[ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "0:0" ]
+lxc exec c1 -- umount /mnt
+
+if hasNeededAPIExtension container_syscall_intercept_mount_fuse; then
+    lxc config unset c1 security.syscalls.intercept.mount.allowed
+    lxc config set c1 security.syscalls.intercept.mount.fuse=ext4=fuse2fs
     lxc restart c1 -f
-    lxc exec c1 -- mount /dev/sda /mnt
-    [ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "65534:65534" ]
-    lxc exec c1 -- umount /mnt
 
-    lxc config set c1 security.syscalls.intercept.mount.shift=true
     lxc exec c1 -- mount /dev/sda /mnt
     [ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "0:0" ]
     lxc exec c1 -- umount /mnt
-
-    if hasNeededAPIExtension container_syscall_intercept_mount_fuse; then
-        lxc config unset c1 security.syscalls.intercept.mount.allowed
-        lxc config set c1 security.syscalls.intercept.mount.fuse=ext4=fuse2fs
-        lxc restart c1 -f
-
-        lxc exec c1 -- mount /dev/sda /mnt
-        [ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "0:0" ]
-        lxc exec c1 -- umount /mnt
-    else
-        echo "Skipping mount fuse tests as the container_syscall_intercept_mount_fuse API extension is missing"
-    fi
-
-    ## cleanup
-    lxc delete -f c1
-    losetup -d "${LOOP}"
-    rm -f loop.img
 else
-    echo "Skipping mount tests as the container_syscall_intercept_mount API extension is missing"
+    echo "Skipping mount fuse tests as the container_syscall_intercept_mount_fuse API extension is missing"
 fi
+
+## cleanup
+lxc delete -f c1
+losetup -d "${LOOP}"
+rm -f loop.img
 
 # shellcheck disable=SC2034
 FAIL=0


### PR DESCRIPTION
I did a bit of cleanup and enabled `tests/interception` on `5.0/*` as it works there and I couldn't remember why I decided to exclude it.