### PR TITLE
Wait instance to be ready

### DIFF
--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -18,7 +18,7 @@ jobs:
         release:
           - buster
           - bullseye
-          - sid
+          #- sid
           - bookworm
           - trixie
         variant:

--- a/bin/helpers
+++ b/bin/helpers
@@ -25,7 +25,7 @@ waitInstanceReady() (
   processes=0
   for _ in $(seq "${maxWait}"); do
       processes="$(lxc info --project "${instProj}" "${instName}" | awk '{if ($1 == "Processes:") print $2}')"
-      if [ "${processes}" -gt 1 ]; then
+      if [ "${processes}" -ge "${MIN_PROC_COUNT:-2}" ]; then
           return 0 # Success.
       fi
       sleep 1

--- a/bin/test-image
+++ b/bin/test-image
@@ -1,5 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
+
+# Source helper functions.
+. $(realpath $(dirname "$0")/helpers)
 
 # Check input arguments.
 if [ "${1:-}" = "" ] || [ "${2:-}" = "" ] || [ "${3:-}" = "" ] || [ "${4:-}" = "" ] || [ "${5:-}" = "" ]; then
@@ -147,8 +150,16 @@ done
 
 # Wait for things to settle.
 echo "==> Waiting for instances to start"
-[ "${TYPE}" = "container" ] && sleep 1m
-[ "${TYPE}" = "vm" ] && sleep 3m
+for i in ${INSTANCES}; do
+    if [ "${DIST}" == "busybox" ]; then
+        MIN_PROC_COUNT=1
+    fi
+
+    waitInstanceReady "${i}"
+done
+
+# Give instances some extra time to boot properly.
+sleep 15
 lxc list "${TEST_IMAGE}"
 
 # Check that all instances have an IPv4 and IPv6 address.


### PR DESCRIPTION
Wait for instance to be ready when testing image builds instead of waiting for a fixed time.
We will see whether this approach will cause any significant issues.

Also this PR disables Debian Sid builds (for now).