### PR TITLE
Run image builds on self-hosted runners

### DIFF
--- a/.github/workflows/image-almalinux.yml
+++ b/.github/workflows/image-almalinux.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   almalinux:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   alpine:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   alt:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-archlinux.yml
+++ b/.github/workflows/image-archlinux.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   archlinux:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-busybox.yml
+++ b/.github/workflows/image-busybox.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   busybox:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   debian:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   devuan:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   fedora:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-funtoo.yml
+++ b/.github/workflows/image-funtoo.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   funtoo:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   gentoo:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-kali.yml
+++ b/.github/workflows/image-kali.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   kali:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-nixos.yml
+++ b/.github/workflows/image-nixos.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   nixos:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   openeuler:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   opensuse:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   openwrt:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-rockylinux.yml
+++ b/.github/workflows/image-rockylinux.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   rockylinux:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/image-voidlinux.yml
+++ b/.github/workflows/image-voidlinux.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   voidlinux:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, jammy, large]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -11,66 +11,66 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  almalinux:
-    uses: ./.github/workflows/image-almalinux.yml
-    secrets: inherit
+  # almalinux:
+  #   uses: ./.github/workflows/image-almalinux.yml
+  #   secrets: inherit
   alpine:
     uses: ./.github/workflows/image-alpine.yml
     secrets: inherit
-  alt:
-    uses: ./.github/workflows/image-alt.yml
-    secrets: inherit
-  amazonlinux:
-    uses: ./.github/workflows/image-amazonlinux.yml
-    secrets: inherit
-  archlinux:
-    uses: ./.github/workflows/image-archlinux.yml
-    secrets: inherit
-  busybox:
-    uses: ./.github/workflows/image-busybox.yml
-    secrets: inherit
-  centos:
-    uses: ./.github/workflows/image-centos.yml
-    secrets: inherit
+  # alt:
+  #   uses: ./.github/workflows/image-alt.yml
+  #   secrets: inherit
+  # amazonlinux:
+  #   uses: ./.github/workflows/image-amazonlinux.yml
+  #   secrets: inherit
+  # archlinux:
+  #   uses: ./.github/workflows/image-archlinux.yml
+  #   secrets: inherit
+  # busybox:
+  #   uses: ./.github/workflows/image-busybox.yml
+  #   secrets: inherit
+  # centos:
+  #   uses: ./.github/workflows/image-centos.yml
+  #   secrets: inherit
   debian:
     uses: ./.github/workflows/image-debian.yml
     secrets: inherit
-  devuan:
-    uses: ./.github/workflows/image-devuan.yml
-    secrets: inherit
-  fedora:
-    uses: ./.github/workflows/image-fedora.yml
-    secrets: inherit
-  funtoo:
-    uses: ./.github/workflows/image-funtoo.yml
-    secrets: inherit
-  gentoo:
-    uses: ./.github/workflows/image-gentoo.yml
-    secrets: inherit
-  kali:
-    uses: ./.github/workflows/image-kali.yml
-    secrets: inherit
-  nixos:
-    uses: ./.github/workflows/image-nixos.yml
-    secrets: inherit
-  openeuler:
-    uses: ./.github/workflows/image-openeuler.yml
-    secrets: inherit
-  opensuse:
-    uses: ./.github/workflows/image-opensuse.yml
-    secrets: inherit
-  openwrt:
-    uses: ./.github/workflows/image-openwrt.yml
-    secrets: inherit
-  oracle:
-    uses: ./.github/workflows/image-oracle.yml
-    secrets: inherit
-  rockylinux:
-    uses: ./.github/workflows/image-rockylinux.yml
-    secrets: inherit
+  # devuan:
+  #   uses: ./.github/workflows/image-devuan.yml
+  #   secrets: inherit
+  # fedora:
+  #   uses: ./.github/workflows/image-fedora.yml
+  #   secrets: inherit
+  # funtoo:
+  #   uses: ./.github/workflows/image-funtoo.yml
+  #   secrets: inherit
+  # gentoo:
+  #   uses: ./.github/workflows/image-gentoo.yml
+  #   secrets: inherit
+  # kali:
+  #   uses: ./.github/workflows/image-kali.yml
+  #   secrets: inherit
+  # nixos:
+  #   uses: ./.github/workflows/image-nixos.yml
+  #   secrets: inherit
+  # openeuler:
+  #   uses: ./.github/workflows/image-openeuler.yml
+  #   secrets: inherit
+  # opensuse:
+  #   uses: ./.github/workflows/image-opensuse.yml
+  #   secrets: inherit
+  # openwrt:
+  #   uses: ./.github/workflows/image-openwrt.yml
+  #   secrets: inherit
+  # oracle:
+  #   uses: ./.github/workflows/image-oracle.yml
+  #   secrets: inherit
+  # rockylinux:
+  #   uses: ./.github/workflows/image-rockylinux.yml
+  #   secrets: inherit
   # ubuntu:
   #   uses: ./.github/workflows/image-ubuntu.yml
   #   secrets: inherit
-  voidlinux:
-    uses: ./.github/workflows/image-voidlinux.yml
-    secrets: inherit
+  # voidlinux:
+  #   uses: ./.github/workflows/image-voidlinux.yml
+  #   secrets: inherit


### PR DESCRIPTION
This should run image builds on the self-hosted runners. 

I've temporary disabled the majority of image builds to not waste the resources in case something goes wrong.

I'm not sure if `focal` runners are available, as those could be required for certain images (such as Orcale and AmazonLinux) if jammy ones do not support cgroups v1.