### PR TITLE
Remove `extra_cleanup()`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
           sudo snap remove lxd --purge
           # Purge older snap revisions that are disabled/superseded by newer revisions of the same snap
           snap list --all | while read -r name _ rev _ _ notes _; do
-            [ "${notes}" = "disabled" ] && snap remove "${name}" --revision "${rev}" --purge
+            [[ "${notes}" =~ disabled$ ]] && snap remove "${name}" --revision "${rev}" --purge
           done || true
 
           # This was inspired from https://github.com/easimon/maximize-build-space

--- a/bin/helpers
+++ b/bin/helpers
@@ -167,12 +167,6 @@ createPowerFlexPool() (
 
 # cleanup: report if the test passed or not and return the appropriate return code.
 cleanup() {
-    # Run any extra cleanup function
-    if command -v extra_cleanup > /dev/null; then
-      trap
-      extra_cleanup
-    fi
-
     set +e
     echo ""
     if [ "${FAIL}" = "1" ]; then

--- a/tests/cgroup
+++ b/tests/cgroup
@@ -10,10 +10,6 @@ install_lxd
 # Configure LXD
 lxd init --auto
 
-# Cleanup
-extra_cleanup() {
-    lxc delete -f c1
-}
 
 # Test
 set -x
@@ -246,6 +242,9 @@ echo "==> Testing the freezer"
 lxc pause c1
 ! lxc exec c1 bash || false
 lxc start c1
+
+echo "==> Cleaning up"
+lxc delete -f c1
 
 # shellcheck disable=SC2034
 FAIL=0

--- a/tests/cluster
+++ b/tests/cluster
@@ -8,6 +8,7 @@ install_lxd
 lxd init --auto
 
 PREFIX="cluster-$$"
+SIZE="$1"
 
 if [ -z "${1:-""}" ] || [ -z "${2:-""}" ] || [ -z "${3:-""}" ]; then
     echo "Usage: ${0} <count> <source channel> <destination channel>"
@@ -23,17 +24,6 @@ print_log() {
     cat "${log_file}" || true
     echo "<== End log file ${1}"
     rm -f "${log_file}"
-}
-
-# Cleanup on shutdown
-SIZE="$1"
-extra_cleanup() {
-    # Delete the cluster
-    echo "==> Deleting the cluster"
-    for i in $(seq "${SIZE}"); do
-        print_log "${PREFIX}-$i"
-        lxc delete --force "${PREFIX}-$i"
-    done
 }
 
 # Launch the container
@@ -120,6 +110,12 @@ sleep 10
 echo "==> Validating the cluster"
 lxc exec "${PREFIX}-1" -- lxc info
 lxc exec "${PREFIX}-1" -- lxc cluster list
+
+echo "==> Deleting the cluster"
+for i in $(seq "${SIZE}"); do
+    print_log "${PREFIX}-$i"
+    lxc delete --force "${PREFIX}-$i"
+done
 
 # shellcheck disable=SC2034
 FAIL=0

--- a/tests/container-copy
+++ b/tests/container-copy
@@ -7,7 +7,7 @@ set -eu
 install_lxd
 lxd init --auto
 
-# Create a loop device that we can mount as a source for a dir storage pool.
+echo "==> Create a loop device that we can mount as a source for a dir storage pool"
 test_dir="$(mktemp -d XXX.test)"
 loopimg="$(mktemp "${test_dir}/XXX.img")"
 truncate -s 5G "${loopimg}"
@@ -16,11 +16,11 @@ loopdev="$(losetup --show --find "${loopimg}")"
 # Begin Test.
 set -x
 
-# Launch a VM which will be the target of the copy.
+echo "==> Launch a VM which will be the target of the copy"
 lxc launch "${TEST_IMG:-ubuntu-minimal-daily:22.04}" target --vm
 waitInstanceBooted target
 
-# Add the target VM as a remote LXD.
+echo "==> Add the target VM as a remote LXD"
 lxc exec target -- snap install lxd --channel "${LXD_SNAP_CHANNEL}"
 lxc exec target -- lxd init --auto
 lxc exec target -- lxc config set core.https_address=:8443
@@ -29,6 +29,7 @@ lxc remote add target "${token}" --accept-certificate
 
 # Run the test for various filesystems.
 for fs in "xfs" "btrfs" "ext4" ; do
+  echo "==> Testing with ${fs}"
   mkfs.${fs} "${loopdev}"
   disk_dir="$(mktemp -d "${test_dir}/XXX.disk")"
   mount "${loopdev}" "${disk_dir}"

--- a/tests/container-copy
+++ b/tests/container-copy
@@ -13,14 +13,6 @@ loopimg="$(mktemp "${test_dir}/XXX.img")"
 truncate -s 5G "${loopimg}"
 loopdev="$(losetup --show --find "${loopimg}")"
 
-extra_cleanup() {
-  # Clean up LXD and remove the loop device.
-  lxc remote remove target
-  lxc delete target -f
-  losetup --detach "${loopdev}"
-  rm -rf "${test_dir}"
-}
-
 # Begin Test.
 set -x
 
@@ -64,6 +56,11 @@ for fs in "xfs" "btrfs" "ext4" ; do
   wipefs -a "${loopdev}"
 done
 
+echo "==> Clean up LXD and remove the loop device"
+lxc remote remove target
+lxc delete target -f
+losetup --detach "${loopdev}"
+rm -rf "${test_dir}"
 
 # shellcheck disable=SC2034
 FAIL=0

--- a/tests/efi-vars-editor-vm
+++ b/tests/efi-vars-editor-vm
@@ -29,21 +29,6 @@ poolDriver=dir
 echo "==> Create storage pool using driver ${poolDriver}"
 lxc storage create "${poolName}" "${poolDriver}"
 
-extra_cleanup() {
-  echo "==> extra_cleanup"
-
-  echo "==> Stopping and deleting VM"
-  lxc delete -f v1
-
-  lxc profile device remove default eth0
-
-  echo "==> Deleting storage pool"
-  lxc storage delete "${poolName}"
-
-  echo "==> Deleting network"
-  lxc network delete lxdbr0
-}
-
 echo "==> Create VM and boot"
 lxc launch "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
 lxc info v1
@@ -84,6 +69,18 @@ echo "==> Start VM and check that variable does not exist anymore"
 lxc start v1
 waitInstanceReady v1
 ! lxc exec v1 -- test -e /sys/firmware/efi/efivars/"${EFI_VAR_FULL_NAME}" || false
+
+# Cleanup
+echo "==> Stopping and deleting VM"
+lxc delete -f v1
+
+lxc profile device remove default eth0
+
+echo "==> Deleting storage pool"
+lxc storage delete "${poolName}"
+
+echo "==> Deleting network"
+lxc network delete lxdbr0
 
 # shellcheck disable=SC2034
 FAIL=0

--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -36,14 +36,6 @@ install_lxd
 # Check that NVIDIA is installed
 nvidia-smi
 
-extra_cleanup() {
-  lxc delete -f c1
-  lxc profile device remove default root
-  lxc profile device remove default eth0
-  lxc storage delete default
-  lxc network delete lxdbr0
-}
-
 # Configure LXD
 lxc storage create default zfs
 lxc profile device add default root disk path=/ pool=default
@@ -121,6 +113,13 @@ lxc config device add c1 gpus gpu vendorid=10de productid="${first_card_product_
 sleep 1
 [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "${total_nvidia_gpu_with_product_id}" ] || false
 lxc exec c1 -- nvidia-smi
+
+echo "==> Cleaning up"
+lxc delete -f c1
+lxc profile device remove default root
+lxc profile device remove default eth0
+lxc storage delete default
+lxc network delete lxdbr0
 
 # shellcheck disable=SC2034
 FAIL=0

--- a/tests/gpu-mig
+++ b/tests/gpu-mig
@@ -19,23 +19,6 @@ install_lxd
 # Check that NVIDIA is installed
 nvidia-smi
 
-extra_cleanup() {
-  lxc delete -f nvidia-mig1
-  lxc delete -f nvidia-mig2
-  lxc delete -f nvidia-mig3
-  lxc delete -f nvidia-mig4
-
-  # Cleanup MIG
-  nvidia-smi mig -dci
-  nvidia-smi mig -dgi
-  nvidia-smi -mig 0
-
-  lxc profile device remove default root
-  lxc profile device remove default eth0
-  lxc storage delete default
-  lxc network delete lxdbr0
-}
-
 # Configure LXD
 lxc storage create default zfs
 lxc profile device add default root disk path=/ pool=default
@@ -109,6 +92,13 @@ lxc stop --all
 nvidia-smi mig -dci
 nvidia-smi mig -dgi
 nvidia-smi -mig 0
+
+echo "==> Cleaning up"
+lxc delete nvidia-mig1 nvidia-mig2 nvidia-mig3 nvidia-mig4
+lxc profile device remove default root
+lxc profile device remove default eth0
+lxc storage delete default
+lxc network delete lxdbr0
 
 # shellcheck disable=SC2034
 FAIL=0

--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -1128,7 +1128,7 @@ ovn_peering_tests() {
     ! lxc exec ovn2 --project=ovn2 -- ping -nc1 -4 -w5 198.51.100.1 || false
     ! lxc exec ovn2 --project=ovn2 -- ping -nc1 -6 -w5 2001:db8:1:2::1 || false
 
-    echo "==> Test that pinging external addresses between networks does worth without peering (goes via uplink)"
+    echo "==> Test that pinging external addresses between networks does work without peering (goes via uplink)"
     lxc exec ovn2 --project=ovn2 -- ping -nc1 -4 -w5 198.51.100.2
     lxc exec ovn2 --project=ovn2 -- ping -nc1 -6 -w5 2001:db8:1:2::2
 
@@ -1136,7 +1136,7 @@ ovn_peering_tests() {
     ip -4 r del 198.51.100.0/24 dev lxdbr0
     ip -6 r del 2001:db8:1:2::/64 dev lxdbr0
 
-    echo "==> Test that pinging external addresses between networks doesn't worth via uplink with removed routes"
+    echo "==> Test that pinging external addresses between networks doesn't work via uplink with removed routes"
     ! lxc exec ovn2 --project=ovn2 -- ping -nc1 -4 -w5 198.51.100.2 || false
     ! lxc exec ovn2 --project=ovn2 -- ping -nc1 -6 -w5 2001:db8:1:2::2 || false
 

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -17,14 +17,6 @@ lxc project create test -c features.images=false
 lxc project switch test
 lxc profile device add default eth0 nic network=lxdbr0
 
-# Cleanup
-extra_cleanup() {
-	lxc profile device remove default eth0
-	lxc project switch default
-	lxc project delete test
-	lxc network delete lxdbr0
-}
-
 poolName="vmpool$$"
 
 for poolDriver in $poolDriverList
@@ -177,6 +169,13 @@ do
 	lxc storage volume rm "${poolName}" vol6 || true  # optional ISO
 	lxc storage rm "${poolName}"
 done
+
+# Cleanup
+echo "==> Cleaning up"
+lxc profile device remove default eth0
+lxc project switch default
+lxc project delete test
+lxc network delete lxdbr0
 
 # shellcheck disable=SC2034
 FAIL=0

--- a/tests/vm-nesting
+++ b/tests/vm-nesting
@@ -11,15 +11,6 @@ lxc project switch default
 lxc storage create default zfs size=30GiB
 lxc network create lxdbr0
 
-# Cleanup
-extra_cleanup() {
-    instCount="$(lxc list -f csv -c n t | wc -l)"
-    [ "$instCount" -gt 0 ] && delete "${instCount}"
-
-    lxc network delete lxdbr0
-    lxc storage delete default
-}
-
 instanceImage="${TEST_IMG:-ubuntu-minimal-daily:22.04}"
 
 function parallel() {
@@ -120,6 +111,13 @@ else
 fi
 cmd 5 "lxd init --auto"
 cmd 5 "lxc launch ${instanceImage} nested --vm -c limits.memory=512MiB -d root,size=3GiB"
+
+echo "==> Cleaning up"
+instCount="$(lxc list -f csv -c n t | wc -l)"
+[ "$instCount" -gt 0 ] && delete "${instCount}"
+
+lxc network delete lxdbr0
+lxc storage delete default
 
 # shellcheck disable=SC2034
 FAIL=0


### PR DESCRIPTION
This `extra_cleanup()` idea was a bad one. We want cleanup steps to run on successful runs and any failure during cleanup should cause a test failure anyway.