### PR TITLE
Remove VM cpu limit in image tests

### DIFF
--- a/bin/test-image
+++ b/bin/test-image
@@ -72,9 +72,9 @@ INSTANCES=""
 if [ "${TYPE}" = "vm" ]; then
     lxc init "${TEST_IMAGE}" "${TEST_IMAGE}" \
         --vm \
-        -c limits.cpu=4 \
         -c limits.memory=4GB \
         -c security.secureboot=false
+        # -c limits.cpu=4 \
 
     INSTANCES="${TEST_IMAGE}"
 


### PR DESCRIPTION
Image build tests are currently failing because `large` self-hosted runners have only 2 CPUs and we cannot allocate more CPUs than available to the VM.

I would prefer not use larger runners (`xlarge`), since there are only 10 available.