### PR TITLE
Increase wait instance ready timeout for image tests

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -13,7 +13,7 @@ waitSnapdSeed() (
 # waitInstanceReady: waits for the instance to be ready (processes count > 1).
 waitInstanceReady() (
   set +x
-  maxWait=120
+  maxWait="${WAIT_READY_TIMEOUT:-120}"
   instName="${1}"
   instProj="${2:-}"
   if [ -z "${instProj}" ]; then

--- a/bin/test-image
+++ b/bin/test-image
@@ -155,7 +155,7 @@ for i in ${INSTANCES}; do
         MIN_PROC_COUNT=1
     fi
 
-    waitInstanceReady "${i}"
+    WAIT_READY_TIMEOUT=240 waitInstanceReady "${i}"
 done
 
 # Give instances some extra time to boot properly.

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+echo $(realpath $(dirname "$0"))


### PR DESCRIPTION
Currently, image VM tests are partially failing because instance is not ready in time (2 minutes). This increases wait instance timeout to 4 minutes in image tests.

Still, this may be a bit concerning as Alpine VMs are not ready within 2 minutes. I'm wondering how long will it take for *heavier* images.