### PR TITLE
efi-vars-editor-vm: add wait for instance to be ready

### DIFF
--- a/tests/efi-vars-editor-vm
+++ b/tests/efi-vars-editor-vm
@@ -31,6 +31,7 @@ lxc storage create "${poolName}" "${poolDriver}"
 
 echo "==> Create VM and boot"
 lxc launch "${TEST_IMG:-ubuntu-minimal-daily:22.04}" v1 --vm -s "${poolName}"
+waitInstanceReady v1
 lxc info v1
 
 EFI_GLOBAL_VARIABLE_GUID="8be4df61-93ca-11d2-aa0d-00e098032b8c"


### PR DESCRIPTION
Attempt to fix:
https://github.com/canonical/lxd-ci/actions/runs/8200639198/job/22427798532?pr=99
```
+ echo '==> Try to set EFI variable while VM is running (should fail)'
+ lxc config uefi set v1 testvar-8be4df61-93ca-11d2-aa0d-00e098032b8c=48656c6c6f2066726f6d204c5844
Error: UEFI variables editing is allowed for stopped VM instances only
+ lxc stop -f v1
+ echo '==> Try to set invalid data as EFI variable value'
==> Try to set invalid data as EFI variable value
+ lxc config uefi set v1 testvar-8be4df61-93ca-11d2-aa0d-00e098032b8c=0
Error: Failed to run: uefivars.py -o json -i edk2: exit status 1 (Reading uefivars from stdin
Traceback (most recent call last):
  File "/snap/lxd/27513/bin/uefivars.py", line 8, in <module>
    sys.exit(main())
  File "/snap/lxd/current/lib/python3/dist-packages/pyuefivars/__init__.py", line 94, in main
    varstore = inclass(indata)
  File "/snap/lxd/current/lib/python3/dist-packages/pyuefivars/edk2.py", line 192, in __init__
    data = file.read(datalen)
  File "/snap/lxd/current/lib/python3/dist-packages/pyuefivars/aws_file.py", line 13, in read
    raise Exception("Unexpected end of %s at 0x%x" % (self.file, self.file.tell()))
Exception: Unexpected end of <tempfile.SpooledTemporaryFile object at 0x7f433ad6c100> at 0x84000)
+ echo '==> Set a valid variable data'
+ lxc config uefi set v1 testvar-8be4df61-93ca-11d2-aa0d-00e098032b8c=48656c6c6f2066726f6d204c5844
==> Set a valid variable data
Error: Failed to run: uefivars.py -o json -i edk2: exit status 1 (Reading uefivars from stdin
Traceback (most recent call last):
  File "/snap/lxd/27513/bin/uefivars.py", line 8, in <module>
    sys.exit(main())
  File "/snap/lxd/current/lib/python3/dist-packages/pyuefivars/__init__.py", line 94, in main
    varstore = inclass(indata)
  File "/snap/lxd/current/lib/python3/dist-packages/pyuefivars/edk2.py", line 192, in __init__
    data = file.read(datalen)
  File "/snap/lxd/current/lib/python3/dist-packages/pyuefivars/aws_file.py", line 13, in read
    raise Exception("Unexpected end of %s at 0x%x" % (self.file, self.file.tell()))
Exception: Unexpected end of <tempfile.SpooledTemporaryFile object at 0x7efdb437c100> at 0x84000)
```

Likely it happens because we stop VM earlier than NVRAM is fully initialized. Let's try to workaround this by adding a wait for instance to be fully ready.