### PR TITLE
tests/cluster: Wait until snapd is seeded

### DIFF
--- a/tests/cluster
+++ b/tests/cluster
@@ -95,6 +95,7 @@ for i in $(seq "${SIZE}"); do
     lxc exec "${PREFIX}-$i" -- snap refresh
     lxc exec "${PREFIX}-$i" -- snap switch lxd --channel="$3"
     if [ "$i" = "${SIZE}" ]; then
+        lxc exec "${PREFIX}-$i" -- snap wait system seed.loaded
         lxc exec "${PREFIX}-$i" -- timeout 10m snap refresh lxd
     fi
 done


### PR DESCRIPTION
This should address failures of the `tests/cluster` suite in case snapd isn't yet ready. This happened in one of the pipelines e.g. https://github.com/canonical/lxd-ci/actions/runs/8261572982/job/22599147506?pr=103. 

The same is done in the `tests/vm-nesting` suite: https://github.com/canonical/lxd-ci/blob/main/tests/vm-nesting#L89