### PR TITLE
Tests: Revert the Btrfs refresh exception

### DIFF
--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -102,11 +102,8 @@ for poolDriver in $poolDriverList; do
         waitInstanceReady v2
         lxc stop -f v2
 
-        # Temporary exception for https://github.com/canonical/lxd/issues/13085.
-        if [ "${poolDriver}" != "btrfs" ]; then
-                echo "==> Checking VM can be refreshed"
-                lxc copy v1 v2 --refresh
-        fi
+        echo "==> Checking VM can be refreshed"
+        lxc copy v1 v2 --refresh
         lxc delete -f v2
 
         echo "==> Checking running copied VM snapshot"


### PR DESCRIPTION
The refresh got fixed in https://github.com/canonical/lxd/pull/13133.