### PR TITLE
github/workflow: Drop Fedora 37

### DIFF
--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -21,7 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 37
           - 38
           - 39
         variant:


### PR DESCRIPTION
Drop Fedora 37 (EOL).