### PR TITLE
Use SFTP instead of SCP to upload images

### DIFF
--- a/.github/actions/image-upload/action.yml
+++ b/.github/actions/image-upload/action.yml
@@ -57,7 +57,8 @@ runs:
         # Move image content.
         mv ${SRC_DIR}/* "${PRODUCT_PATH}/${VERSION}"
 
-        # s -> Uses SFTP protocol
-        # r -> Copies files recursively
-        # p -> Preserves modification and access times
-        scp -srp -P ${SSH_PORT} ${SRC_DIR}-upload/* "${SSH_USER}@${SSH_HOST}:"
+        # Use SFTP to upload images to the server.
+        sftp -P ${SSH_PORT} "${SSH_USER}@${SSH_HOST}" <<EOF
+            put -r ${SRC_DIR}-upload/*
+            bye
+        EOF


### PR DESCRIPTION
SCP flag `-s` (*Use the SFTP protocol for transfers rather than the original scp protocol.*) is not supported on older runners (specifically 20.04), therefore, use SFTP client for file transfer.