### PR TITLE
Disable scheduled build for Ubuntu images

### DIFF
--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -1,9 +1,9 @@
 name: Build Ubuntu Images
 
 on:
-  schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+  # schedule:
+  #   # Run at 00:00 UTC daily.
+  #   - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       publish:


### PR DESCRIPTION
I've accidentally enabled scheduled Ubuntu build in #120