### PR TITLE
Fix CentOS timeout on boot during test

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -13,7 +13,7 @@ waitSnapdSeed() (
 # waitInstanceReady: waits for the instance to be ready (processes count > 1).
 waitInstanceReady() (
   set +x
-  maxWait=120
+  maxWait="${MAX_WAIT_SECONDS:-120}"
   instName="${1}"
   instProj="${2:-}"
   if [ -z "${instProj}" ]; then

--- a/bin/test-image
+++ b/bin/test-image
@@ -152,7 +152,13 @@ done
 echo "==> Waiting for instances to start"
 for i in ${INSTANCES}; do
     if [ "${DIST}" == "busybox" ]; then
+        # Busybox has only 1 process running when ready.
         MIN_PROC_COUNT=1
+    fi
+
+    if [ "${DIST}" == "centos" ]; then
+        # Give CentOS a bit more time to boot.
+        MAX_WAIT_SECONDS=180
     fi
 
     waitInstanceReady "${i}"


### PR DESCRIPTION
Tests for CentOS images are occasionally failing, therefore give CentOS images an extra minute to boot.