### PR TITLE
images/opensuse: Remove 15.4 (EOL)

### DIFF
--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 15.4
           - 15.5
           - tumbleweed
         variant:

--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -106,7 +106,6 @@ files:
   types:
   - vm
   releases:
-  - 15.4
   - 15.5
 
 - name: ifcfg-enp5s0


### PR DESCRIPTION
Remove OpenSUSE 15.4 because it has reached EOL