### PR TITLE
images/ubuntu: Enable desktop builds

### DIFF
--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -1,9 +1,9 @@
 name: Build Ubuntu Images
 
 on:
-  # schedule:
-  #   # Run at 00:00 UTC daily.
-  #   - cron: '0 0 * * *'
+  schedule:
+    # Run at 00:00 UTC daily.
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       publish:
@@ -19,15 +19,15 @@ jobs:
       matrix:
         release:
           # - xenial
-          - bionic
+          # - bionic
           - focal
           - jammy
           - mantic
           - noble
         variant:
-          - default
           - desktop
-          - cloud
+          # - default
+          # - cloud
         architecture:
           - amd64
           # - arm64

--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -3,18 +3,17 @@ image:
 
 simplestream:
   release_aliases:
-    xenial: 16.04
-    bionic: 18.04
+    # xenial: 16.04
+    # bionic: 18.04
     focal: 20.04
     jammy: 22.04
-    lunar: 23.04
     mantic: 23.10
     noble: 24.04
   requirements:
-  - requirements:
-      cgroup: v1
-    releases:
-    - xenial
+  # - requirements:
+  #     cgroup: v1
+  #   releases:
+  #   - xenial
   - requirements:
       cgroup: v2
     releases:


### PR DESCRIPTION
Enable Ubuntu desktop builds for Focal, Jammy, Mantic, and Noble releases.