### PR TITLE
Temporary disable failing images

### DIFF
--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -29,6 +29,7 @@ jobs:
           # - arm64
         exclude:
           - { architecture: arm64, variant: desktop-kde }
+          - { release: 15.5, variant: cloud }
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
           - focal
           - jammy
           - mantic
-          - noble
+          # - noble
         variant:
           - desktop
           # - default


### PR DESCRIPTION
Disable images that are consistently failing until issues are resolved:
- `opensuse/15.5/cloud`
- `ubuntu/noble` (desktop)