### PR TITLE
Upload Slackware images when event_type is schedule

### DIFF
--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: inputs.publish == true
+        if: github.event_name == 'schedule' || inputs.publish == true
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"


### PR DESCRIPTION
Publish slackware images when event type is schedule.
Seems that I've missed that one. Others are uploading as expected.