### PR TITLE
bin/helpers: check for unexpected LXD warnings/errors during cleanup()

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -184,6 +184,7 @@ certificateFingerprintShort() (
 )
 
 # cleanup: report if the test passed or not and return the appropriate return code.
+# Also fail the test if unexpected warnings/errors are logged by LXD
 cleanup() {
     set +e
     echo ""
@@ -208,6 +209,19 @@ cleanup() {
         echo "::endgroup::"
 
         exit 1
+    else
+        # The test passed but check for unexpected warnings/errors
+        problems="$(journalctl --quiet --no-hostname --output cat --no-pager --boot=0 --lines=100 --unit=snap.lxd.daemon.service --grep ' level=(warning|error) ' | \
+                    grep -vF 'per-instance network priority will be ignored. Please use per-device limits.priority instead')"
+        if [ -n "${problems}" ]; then
+           echo "Test failed"
+
+           echo "Unexpected LXD warnings/errors:"
+           echo
+           echo "${problems}"
+
+           exit 1
+        fi
     fi
 
     echo "Test passed"


### PR DESCRIPTION
This brings the question of should we keep warning about this:

```
time="2024-04-09T19:46:28-04:00" level=warning msg=" - Couldn't find the CGroup network priority controller, per-instance network priority will be ignored. Please use per-device limits.priority instead"
```

I have this warning locally despite not making conscious use of any network priority. I've also ACK'ed the corresponding `lxc warning` but it doesn't silence that message.