### PR TITLE
tests/interception: only try to enable shiftfs on 5.0/* snap

### DIFF
--- a/tests/interception
+++ b/tests/interception
@@ -8,7 +8,10 @@ install_deps attr
 install_lxd
 
 # Configure LXD
-snap set lxd shiftfs.enable=true
+if echo "${LXD_SNAP_CHANNEL}" | grep -q '^5\.0/'; then
+    echo "Enabling shiftfs support"
+    snap set lxd shiftfs.enable=true
+fi
 lxd init --auto
 
 # Test


### PR DESCRIPTION
When the snap doesn't support shiftfs (anything after 5.20), the key is set but ignore so it didn't cause any problem.

Putting that version detection in place will hopefully let me remember to drop it once 5.0 goes EOL.