### PR TITLE
Clone lxd-imagebuilder using git

### DIFF
--- a/.github/actions/image-setup/action.yml
+++ b/.github/actions/image-setup/action.yml
@@ -15,13 +15,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout LXD imagebuilder
-      uses: actions/checkout@v4
-      with:
-        repository: canonical/lxd-imagebuilder
-        path: lxd-imagebuilder
-        ssh-key: ${{ inputs.ssh-key }}
-
     - name: Install dependencies
       shell: bash
       run: |
@@ -39,10 +32,10 @@ runs:
       with:
         go-version: "${{ inputs.go-version }}"
 
-    # - name: Clone LXD imagebuilder
-    #   shell: bash
-    #   run: |
-    #     git clone https://github.com/canonical/lxd-imagebuilder --depth 1
+    - name: Clone LXD imagebuilder
+      shell: bash
+      run: |
+        git clone https://github.com/canonical/lxd-imagebuilder --depth 1
 
     - name: Build LXD imagebuilder
       shell: bash


### PR DESCRIPTION
lxd-imagebuilder repository is now public so we can directly clone it instead of using deploy keys.