### PR TITLE
image-setup: Add missing make package

### DIFF
--- a/.github/actions/image-setup/action.yml
+++ b/.github/actions/image-setup/action.yml
@@ -21,9 +21,10 @@ runs:
         sudo apt-get -qq update
         sudo apt-get install -y --no-install-recommends \
             debootstrap \
-            qemu-utils \
             git \
             gpg \
+            make
+            qemu-utils \
             rsync \
             squashfs-tools
 


### PR DESCRIPTION
Missing `make` package..

If there will be more issues, I will disable other builds and ssh into the instance using tmux, as I have no other options to test this before opening a PR..