### PR TITLE
Add Linux Mint

### DIFF
--- a/.github/actions/image-setup/action.yml
+++ b/.github/actions/image-setup/action.yml
@@ -8,9 +8,6 @@ inputs:
   go-version:
     description: Go version to install
     default: 1.22.x
-  ssh-key:
-    description: LXD imagebuilder deployment key
-    required: true
 
 runs:
   using: composite

--- a/.github/workflows/image-almalinux.yml
+++ b/.github/workflows/image-almalinux.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/.github/workflows/image-amazonlinux.yml
+++ b/.github/workflows/image-amazonlinux.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/.github/workflows/image-archlinux.yml
+++ b/.github/workflows/image-archlinux.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-busybox.yml
+++ b/.github/workflows/image-busybox.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-funtoo.yml
+++ b/.github/workflows/image-funtoo.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-kali.yml
+++ b/.github/workflows/image-kali.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -1,0 +1,87 @@
+name: Build Linux Mint Images
+
+on:
+  schedule:
+    # Run at 00:00 UTC daily.
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      publish:
+        type: boolean
+        default: false
+        description: Publish built image
+
+jobs:
+  mint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release:
+          - una
+          - virginia
+        variant:
+          - default
+          - cloud
+        architecture:
+          - amd64
+    env:
+      type: "container"
+      distro: "${{ github.job }}"
+      target: "${HOME}/build"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/image-setup
+
+      - name: Build image
+        run: |
+          TIMEOUT=1800
+          YAML="${{ github.workspace }}/images/${{ env.distro }}.yaml"
+          ARCH="${{ matrix.architecture }}"
+          TYPE="${{ env.type }}"
+          RELEASE="${{ matrix.release}}"
+
+          SUITE="jammy"
+          if [ "${RELEASE}" = "una" ]; then
+              SUITE=focal
+          fi
+
+          ./bin/build-distro "${YAML}" "${ARCH}" "${TYPE}" "${TIMEOUT}" "${{ env.target }}" \
+              -o image.architecture="${ARCH}" \
+              -o image.release=${{ matrix.release }} \
+              -o image.variant=${{ matrix.variant }} \
+              -o source.suite="${SUITE}"
+
+      - name: Print build artifacts
+        run: ls -lah "${{ env.target }}"
+
+      - name: Test container image
+        uses: ./.github/actions/image-test
+        if: contains(env.type, 'container')
+        with:
+          type: container
+          target: ${{ env.target }}
+          distro: ${{ env.distro }}
+          release: ${{ matrix.release }}
+          variant: ${{ matrix.variant }}
+
+      - name: Test VM image
+        uses: ./.github/actions/image-test
+        if: contains(env.type, 'vm')
+        with:
+          type: vm
+          target: ${{ env.target }}
+          distro: ${{ env.distro }}
+          release: ${{ matrix.release }}
+          variant: ${{ matrix.variant }}
+
+     - name: Upload image
+        uses: ./.github/actions/image-upload
+        if: github.event_name == 'schedule' || inputs.publish == true
+        with:
+          target: ${{ env.target }}
+          image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"
+          ssh_private_key: "${{ secrets.LXD_INFRA_IMAGES_KEY }}"

--- a/.github/workflows/image-nixos.yml
+++ b/.github/workflows/image-nixos.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/.github/workflows/image-rockylinux.yml
+++ b/.github/workflows/image-rockylinux.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Determine image types
         run: |

--- a/.github/workflows/image-voidlinux.yml
+++ b/.github/workflows/image-voidlinux.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/image-setup
-        with:
-          ssh-key: ${{ secrets.LXD_IMAGEBUILDER_KEY }}
 
       - name: Build image
         run: |

--- a/images/mint.yaml
+++ b/images/mint.yaml
@@ -1,6 +1,11 @@
 image:
   distribution: "mint"
 
+simplestream:
+  release_aliases:
+    una: 20.3
+    virginia: 21.3
+
 source:
   downloader: debootstrap
   same_as: gutsy


### PR DESCRIPTION
Add Linux Mint daily builds and remove no longer used deploy keys.

@tomponline Secret `LXD_IMAGEBUILDER_KEY` can be removed. I guess it was not, since builds did not complain.