### PR TITLE
github: fix image-mint.yml syntax

### DIFF
--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -78,7 +78,7 @@ jobs:
           release: ${{ matrix.release }}
           variant: ${{ matrix.variant }}
 
-     - name: Upload image
+      - name: Upload image
         uses: ./.github/actions/image-upload
         if: github.event_name == 'schedule' || inputs.publish == true
         with:


### PR DESCRIPTION
Before that:

```
$ yamllint .github/workflows/image-mint.yml 
.github/workflows/image-mint.yml
  1:1       warning  missing document start "---"  (document-start)
  3:1       warning  truthy value should be one of [false, true]  (truthy)
  52:81     warning  line too long (93 > 80 characters)  (line-length)
  81:6      error    syntax error: expected <block end>, but found '<block sequence start>' (syntax)
  86:81     warning  line too long (110 > 80 characters)  (line-length)
```

After that adding the missing space:

```
$ yamllint .github/workflows/image-mint.yml 
.github/workflows/image-mint.yml
  1:1       warning  missing document start "---"  (document-start)
  3:1       warning  truthy value should be one of [false, true]  (truthy)
  52:81     warning  line too long (93 > 80 characters)  (line-length)
  86:81     warning  line too long (111 > 80 characters)  (line-length)
```
