### PR TITLE
github/workflows: Use Funtoo next release

### DIFF
--- a/.github/workflows/image-funtoo.yml
+++ b/.github/workflows/image-funtoo.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 1.4
+          - next
         variant:
           - default
         architecture:


### PR DESCRIPTION
Funtoo `1.4` is EOL. Use `next` release.

https://www.funtoo.org/Support_Matrix

Closes: https://github.com/canonical/lxd/issues/13352