### PR TITLE
images: Disable Alpine arm64 VMs

### DIFF
--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Determine image types
         run: |
           ARCH="${{ matrix.architecture }}"
-          if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then
+          if [ "${ARCH}" = "amd64" ]; then
             echo "type=container,vm" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -36,6 +36,7 @@ jobs:
         build_arm64:
           - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
         exclude:
+          - {architecture: amd64, build_arm64: true}
           - {architecture: arm64, build_arm64: false}
     env:
       type: "container"


### PR DESCRIPTION
Temporary disable arm64 VM builds.

Also do not build amd64 images when building arm64 images. This ensures we do not republish amd64 images when arm64 images built (especially now during testing), as it will make delta files from previous days useless.