### PR TITLE
images: Enable arm64 container builds

### DIFF
--- a/.github/workflows/image-almalinux.yml
+++ b/.github/workflows/image-almalinux.yml
@@ -2,18 +2,22 @@ name: Build AlmaLinux Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   almalinux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +29,12 @@ jobs:
           - cloud
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -2,18 +2,22 @@ name: Build ALT Linux Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   alt:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +30,12 @@ jobs:
           - cloud
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-amazonlinux.yml
+++ b/.github/workflows/image-amazonlinux.yml
@@ -2,18 +2,22 @@ name: Build AmazonLinux Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   amazonlinux:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-20.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +28,13 @@ jobs:
           - default
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
+          - {architecture: arm64, release: 2}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-archlinux.yml
+++ b/.github/workflows/image-archlinux.yml
@@ -2,18 +2,22 @@ name: Build ArchLinux Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   archlinux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,8 +29,12 @@ jobs:
           - desktop-gnome
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
         exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
           - {architecture: arm64, variant: cloud}
           - {architecture: arm64, variant: desktop-gnome}
     env:

--- a/.github/workflows/image-busybox.yml
+++ b/.github/workflows/image-busybox.yml
@@ -2,18 +2,22 @@ name: Build BusyBox Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   busybox:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +27,12 @@ jobs:
           - default
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -2,18 +2,22 @@ name: Build CentOS Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   centos:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-20.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +30,13 @@ jobs:
           - cloud
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
+          - {architecture: arm64, release: 7}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -2,18 +2,22 @@ name: Build Debian Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   debian:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +32,12 @@ jobs:
           - cloud
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Determine image types
         run: |
           ARCH="${{ matrix.architecture }}"
-          if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then
+          if [ "${ARCH}" = "amd64" ]; then
               echo "type=container,vm" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -2,18 +2,22 @@ name: Build Devuan Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   devuan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +30,12 @@ jobs:
           - cloud
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -2,18 +2,22 @@ name: Build Fedora Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   fedora:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +29,12 @@ jobs:
           - cloud
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Determine image types
         run: |
           ARCH="${{ matrix.architecture }}"
-          if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then
+          if [ "${ARCH}" = "amd64" ]; then
               echo "type=container,vm" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/image-funtoo.yml
+++ b/.github/workflows/image-funtoo.yml
@@ -2,18 +2,22 @@ name: Build Funtoo Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   funtoo:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +27,12 @@ jobs:
           - default
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -2,18 +2,22 @@ name: Build Gentoo Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   gentoo:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +28,12 @@ jobs:
           - systemd
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-kali.yml
+++ b/.github/workflows/image-kali.yml
@@ -2,18 +2,22 @@ name: Build Kali Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   kali:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +28,12 @@ jobs:
           - cloud
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -2,8 +2,7 @@ name: Build Linux Mint Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-nixos.yml
+++ b/.github/workflows/image-nixos.yml
@@ -2,18 +2,22 @@ name: Build NixOS Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   nixos:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +28,12 @@ jobs:
           - default
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -2,18 +2,22 @@ name: Build openEuler Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   openeuler:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +30,12 @@ jobs:
           - cloud
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -2,18 +2,22 @@ name: Build OpenSUSE Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   opensuse:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,8 +30,12 @@ jobs:
           - desktop-kde
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
         exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
           - {architecture: arm64, variant: desktop-kde}
           - {release: 15.5, variant: cloud}
     env:

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Determine image types
         run: |
           ARCH="${{ matrix.architecture }}"
-          if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then
+          if [ "${ARCH}" = "amd64" ]; then
               echo "type=container,vm" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -2,18 +2,22 @@ name: Build OpenWRT Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   openwrt:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +29,12 @@ jobs:
           - default
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -2,18 +2,22 @@ name: Build Oracle Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   oracle:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-20.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +30,13 @@ jobs:
           - cloud
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
+          - {architecture: arm64, release: 7}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-rockylinux.yml
+++ b/.github/workflows/image-rockylinux.yml
@@ -2,18 +2,22 @@ name: Build RockyLinux Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   rockylinux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +29,12 @@ jobs:
           - cloud
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -2,8 +2,7 @@ name: Build Slackware Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -2,8 +2,7 @@ name: Build Ubuntu Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Determine image types
         run: |
           ARCH="${{ matrix.architecture }}"
-          if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then
+          if [ "${ARCH}" = "amd64" ]; then
               echo "type=container,vm" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/image-voidlinux.yml
+++ b/.github/workflows/image-voidlinux.yml
@@ -2,18 +2,22 @@ name: Build VoidLinux Images
 
 on:
   schedule:
-    # Run at 00:00 UTC daily.
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1' # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   voidlinux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +28,12 @@ jobs:
           - default
         architecture:
           - amd64
-          # - arm64
+          - arm64
+        build_arm64:
+          - ${{ inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1' }}
+        exclude:
+          - {architecture: amd64, build_arm64: true}
+          - {architecture: arm64, build_arm64: false}
     env:
       type: "container"
       distro: "${{ github.job }}"


### PR DESCRIPTION
Enable arm64 container image builds.

I've also disabled arm64 image builds for images that require cgroup v1.