### PR TITLE
Revert "github/workflows: Disable Debian Sid"

### DIFF
--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -24,7 +24,7 @@ jobs:
         release:
           - buster
           - bullseye
-          #- sid
+          - sid
           - bookworm
           - trixie
         variant:

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -67,7 +67,7 @@ jobs:
               -o image.architecture=${{ matrix.architecture }} \
               -o image.release=${{ matrix.release }} \
               -o image.variant=${{ matrix.variant }} \
-              -o source.url="http://ftp.us.debian.org/debian"
+              -o source.url="https://deb.debian.org/debian"
 
       - name: Print build artifacts
         run: ls -lah "${{ env.target }}"


### PR DESCRIPTION
Let's try it again, assuming the `t64` transition is over with.

This reverts commit b21d51e4816a6a5d81f38a59583acf6847b18e46.