### PR TITLE
images: Ubuntu Noble desktop

### DIFF
--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
           - focal
           - jammy
           - mantic
-          # - noble
+          - noble
         variant:
           - desktop
           # - default

--- a/images/ubuntu.yaml
+++ b/images/ubuntu.yaml
@@ -671,11 +671,23 @@ actions:
     #!/bin/sh
     set -eux
 
-    # Enable systemd-networkd
-    systemctl enable systemd-networkd
-
     # Disable UA attach
     systemctl mask ua-auto-attach
+
+  # Ubuntu Desktop images come with NetworkManager by default,
+  # so we should stop enabling systemd-networkd from Noble onwards.
+- trigger: post-packages
+  action: |-
+    #!/bin/sh
+    set -eux
+
+    # Enable systemd-networkd
+    systemctl enable systemd-networkd
+  releases:
+  - bionic
+  - focal
+  - jammy
+  - mantic
 
 - trigger: post-packages
   action: |-


### PR DESCRIPTION
Disable systemd-networkd on Ubuntu Noble desktop images which causes delays on boot.

I've left images for previous releases intact, but as @daniloegea suggested, should we disable systemd-networkd for all previous releases as well, if Ubuntu Desktop uses NetworkManager by default?

Closes https://github.com/canonical/lxd/issues/13387