### PR TITLE
bin/build-distro: make it easier to use relative path for YAML

### DIFF
--- a/bin/build-distro
+++ b/bin/build-distro
@@ -18,8 +18,8 @@ shift 5
 CACHE_DIR="${TARGET}/cache"
 mkdir -p "${CACHE_DIR}"
 
+cp "${YAML}" "${TARGET}/image.yaml"
 cd "${TARGET}"
-cp "${YAML}" image.yaml
 
 # Get lxd-imagebuilder path and create a serial.
 BUILDER=$(command -v lxd-imagebuilder)


### PR DESCRIPTION
This way, I can use this invocation:

```
root@t1:~/lxd-ci# ./bin/build-distro "images/ubuntu.yaml" amd64 vm 1800 "${HOME}/build" -o image.architecture=amd64 -o image.release=noble -o image.variant=desktop -o source.url="http://archive.ubuntu.com/ubuntu"
```

Which previously failed due to the earlier `cd`:

```
root@t1:~/lxd-ci# ./bin/build-distro "images/ubuntu.yaml" amd64 vm 1800 "${HOME}/build" -o image.architecture=amd64 -o image.release=noble -o image.variant=desktop -o source.url="http://archive.ubuntu.com/ubuntu"
cp: cannot stat 'images/ubuntu.yaml': No such file or directory
```