### PR TITLE
github: switch to HTTPS URL for debian and use fastly CDN

### DIFF
--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -61,7 +61,7 @@ jobs:
               -o image.architecture=${{ matrix.architecture }} \
               -o image.release=${{ matrix.release }} \
               -o image.variant=${{ matrix.variant }} \
-              -o source.url="http://ftp.us.debian.org/debian"
+              -o source.url="https://deb.debian.org/debian"
 
       - name: Print build artifacts
         run: ls -lah "${{ env.target }}"


### PR DESCRIPTION
The fastly CDN should provide close HTTPS endpoint wherever our GitHub Action runner VMs are located.