### PR TITLE
Fix name of `secureboot` requirement

### DIFF
--- a/.github/actions/image-test/action.yml
+++ b/.github/actions/image-test/action.yml
@@ -36,7 +36,7 @@ runs:
         echo "==> TEST: ${TEST_ID}"
 
         VIRT_ENABLED=$(lxc query /1.0 | jq '.environment.driver | contains("qemu")')
-        if [ ${TYPE} = "vm" ] && [ "${VIRT_ENABLED}" != "true" ]; then
+        if [ "${TYPE}" = "vm" ] && [ "${VIRT_ENABLED}" != "true" ]; then
             echo "==> FAIL: Virtualization is not supported"
             exit 1
         fi

--- a/.github/actions/image-test/action.yml
+++ b/.github/actions/image-test/action.yml
@@ -41,12 +41,10 @@ runs:
             exit 1
         fi
 
-        ./bin/test-image "${TYPE}" "${DISTRO}" "${RELEASE}" "${VARIANT}" "${TARGET}"
-
-        if [ "$?" = "0" ]; then
+        if ./bin/test-image "${TYPE}" "${DISTRO}" "${RELEASE}" "${VARIANT}" "${TARGET}"; then
             echo "==> PASS: ${TEST_ID}"
             exit 0
         fi
 
         echo "==> FAIL: ${TEST_ID}"
-        exit 0
+        exit 1

--- a/bin/test-image
+++ b/bin/test-image
@@ -241,7 +241,7 @@ for url in $(lxc query "/1.0/instances" | jq -r .[] | grep "${TEST_IMAGE}"); do
 
     # DNS resolution
     DNS=0
-    for i in $(seq 3); do
+    for _ in $(seq 3); do
         if lxc exec "${name}" -- getent hosts canonical.com >/dev/null 2>&1; then
             DNS=1
             break
@@ -282,7 +282,7 @@ done
 # Check that all instances can be stopped.
 echo "==> Performing shutdown test"
 STOPPED=0
-for i in $(seq 10); do
+for _ in $(seq 10); do
     # shellcheck disable=SC2086
     if lxc stop ${INSTANCES} --timeout=30 >/dev/null 2>&1; then
         STOPPED=1

--- a/bin/test-image
+++ b/bin/test-image
@@ -11,7 +11,7 @@ if [ "${1:-}" = "" ] || [ "${2:-}" = "" ] || [ "${3:-}" = "" ] || [ "${4:-}" = "
 fi
 
 TYPE=${1}
-DIST=${2}
+DISTRO=${2}
 RELEASE=${3}
 VARIANT=${4}
 TARGET=${5}
@@ -30,7 +30,7 @@ fi
 
 # Setup the test environment.
 TEST_DIR="${HOME}/build-test"
-TEST_IMAGE="${TYPE}-${DIST}-${VARIANT}"
+TEST_IMAGE="${TYPE}-${DISTRO}-${VARIANT}"
 
 rm -Rf "${TEST_DIR}"
 mkdir -p "${TEST_DIR}"
@@ -96,7 +96,7 @@ EOF
     fi
 else
     for PRIV in "priv" "unpriv"; do
-        if [ "${PRIV}" = "priv" ] && [ "${DIST}" = "nixos" ] && [ "${RELEASE}" = "23.11" ]; then
+        if [ "${PRIV}" = "priv" ] && [ "${DISTRO}" = "nixos" ] && [ "${RELEASE}" = "23.11" ]; then
             # NixOS 23.11 will never support privileged containers, but future versions do.
             continue
         fi
@@ -111,12 +111,12 @@ else
             lxc config set "${TEST_IMAGE}-${PRIV}" security.privileged=true
         fi
 
-        if [ "${DIST}" = "voidlinux" ]; then
+        if [ "${DISTRO}" = "voidlinux" ]; then
             # Workaround weird init system.
             lxc config set "${TEST_IMAGE}-${PRIV}" raw.lxc lxc.signal.halt=SIGCONT
         fi
 
-        if [ "${DIST}" = "slackware" ]; then
+        if [ "${DISTRO}" = "slackware" ]; then
             # Workaround weird init system.
             lxc config set "${TEST_IMAGE}-${PRIV}" raw.lxc lxc.signal.halt=SIGKILL
         fi
@@ -150,12 +150,12 @@ done
 # Wait for things to settle.
 echo "==> Waiting for instances to start"
 for i in ${INSTANCES}; do
-    if [ "${DIST}" == "busybox" ]; then
+    if [ "${DISTRO}" == "busybox" ]; then
         # Busybox has only 1 process running when ready.
         MIN_PROC_COUNT=1
     fi
 
-    if [ "${DIST}" == "centos" ]; then
+    if [ "${DISTRO}" == "centos" ]; then
         # Give CentOS a bit more time to boot.
         MAX_WAIT_SECONDS=180
     fi
@@ -174,13 +174,13 @@ for url in $(lxc query "/1.0/instances" | jq -r .[] | grep "${TEST_IMAGE}"); do
     name=$(echo "${url}" | cut -d/ -f4)
 
     # Skip busybox as it wouldn't pass any test
-    if [ "${DIST}" = "busybox" ]; then
+    if [ "${DISTRO}" = "busybox" ]; then
         echo "===> SKIP: Busybox is untestable"
         continue
     fi
 
     # Skip CentOS 7 VMs due to racy agent
-    if [ "${TYPE}" = "vm" ] && [ "${DIST}" = "centos" ] && [ "${RELEASE}" = "7" ]; then
+    if [ "${TYPE}" = "vm" ] && [ "${DISTRO}" = "centos" ] && [ "${RELEASE}" = "7" ]; then
         echo "===> SKIP: CentOS 7 has an unstable agent: ${name}"
         continue
     fi

--- a/bin/test-image
+++ b/bin/test-image
@@ -37,11 +37,11 @@ mkdir -p "${TEST_DIR}"
 
 echo "==> Fetching the image"
 if [ "${TYPE}" = "container" ]; then
-    cp "${TARGET}/lxd.tar.xz" "${TEST_DIR}/meta"
-    cp "${TARGET}/rootfs.squashfs" "${TEST_DIR}/root"
+    TEST_IMAGE_META="${TARGET}/lxd.tar.xz"
+    TEST_IMAGE_ROOT="${TARGET}/rootfs.squashfs"
 elif [ "${TYPE}" = "vm" ]; then
-    cp "${TARGET}/lxd.tar.xz" "${TEST_DIR}/meta"
-    cp "${TARGET}/disk.qcow2" "${TEST_DIR}/root"
+    TEST_IMAGE_META="${TARGET}/lxd.tar.xz"
+    TEST_IMAGE_ROOT="${TARGET}/disk.qcow2"
 else
     echo "==> FAIL: Invalid instance type '${TYPE}'. Valid types: [container, vm]"
     exit 1
@@ -64,7 +64,7 @@ cleanup() {
 FAIL=1
 trap cleanup EXIT HUP INT TERM
 
-lxc image import "${TEST_DIR}/meta" "${TEST_DIR}/root" --alias "${TEST_IMAGE}"
+lxc image import "${TEST_IMAGE_META}" "${TEST_IMAGE_ROOT}" --alias "${TEST_IMAGE}"
 
 echo "==> Creating the instances"
 INSTANCES=""

--- a/bin/test-image
+++ b/bin/test-image
@@ -193,7 +193,7 @@ for url in $(lxc query "/1.0/instances" | jq -r .[] | grep "${TEST_IMAGE}"); do
 
     # Systemd cleanliness.
     if lxc exec "${name}" -- test -d /run/systemd/system/; then
-        if lxc exec "${name}" -- systemctl --failed 2>&1 | grep -q '\sfailed\s'; then
+        if lxc exec "${name}" -- systemctl --failed 2>&1 | grep -qwF 'failed'; then
             echo "===> FAIL: systemd clean: ${name}"
 
             # Show the systemd failures.
@@ -224,7 +224,7 @@ for url in $(lxc query "/1.0/instances" | jq -r .[] | grep "${TEST_IMAGE}"); do
     fi
 
     # IPv4 address
-    if echo "${address}" | grep "\." -q; then
+    if echo "${address}" | grep -qF "."; then
         echo "===> PASS: IPv4 address: ${name}"
     else
         echo "===> FAIL: IPv4 address: ${name}"
@@ -232,7 +232,7 @@ for url in $(lxc query "/1.0/instances" | jq -r .[] | grep "${TEST_IMAGE}"); do
     fi
 
     # IPv6 address
-    if echo "${address}" | grep ":" -q; then
+    if echo "${address}" | grep -qF ":"; then
         echo "===> PASS: IPv6 address: ${name}"
     else
         echo "===> FAIL: IPv6 address: ${name}"
@@ -288,7 +288,7 @@ for i in $(seq 10); do
         STOPPED=1
         break
     else
-        COUNT="$(lxc list "${TEST_IMAGE}" | grep -c RUNNING)"
+        COUNT="$(lxc list -f csv -c n,s "${TEST_IMAGE}" | grep -cw 'RUNNING$')"
         if [ "${COUNT}" = "0" ]; then
             STOPPED=1
             break

--- a/bin/test-image
+++ b/bin/test-image
@@ -72,7 +72,7 @@ if [ "${TYPE}" = "vm" ]; then
     lxc init "${TEST_IMAGE}" "${TEST_IMAGE}" \
         --vm \
         -c limits.cpu=4 \
-        -c limits.memory=4GB \
+        -c limits.memory=4GiB \
         -c security.secureboot=false
 
     INSTANCES="${TEST_IMAGE}"

--- a/bin/test-image
+++ b/bin/test-image
@@ -72,8 +72,14 @@ if [ "${TYPE}" = "vm" ]; then
     lxc init "${TEST_IMAGE}" "${TEST_IMAGE}" \
         --vm \
         -c limits.cpu=4 \
-        -c limits.memory=4GiB \
-        -c security.secureboot=false
+        -c limits.memory=4GiB
+
+    # Some distros don't support secure boot.
+    case "${DISTRO}" in
+        alpine|archlinux|gentoo|nixos)
+            lxc config set "${TEST_IMAGE}" security.secureboot=false
+            ;;
+    esac
 
     INSTANCES="${TEST_IMAGE}"
 

--- a/bin/test-image
+++ b/bin/test-image
@@ -192,7 +192,7 @@ for url in $(lxc query "/1.0/instances" | jq -r .[] | grep "${TEST_IMAGE}"); do
     fi
 
     # Systemd cleanliness.
-    if lxc exec "${name}" -- sh -c "type systemctl" >/dev/null 2>&1; then
+    if lxc exec "${name}" -- test -d /run/systemd/system/; then
         if lxc exec "${name}" -- systemctl --failed 2>&1 | grep -q '\sfailed\s'; then
             echo "===> FAIL: systemd clean: ${name}"
 

--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -4,7 +4,7 @@ image:
 simplestream:
   requirements:
   - requirements:
-      secure_boot: false
+      secureboot: false
 
 source:
   downloader: alpinelinux-http

--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -5,7 +5,7 @@ simplestream:
   distro_name: Arch Linux
   requirements:
   - requirements:
-      secure_boot: false
+      secureboot: false
 
 source:
   downloader: archlinux-http

--- a/images/gentoo.yaml
+++ b/images/gentoo.yaml
@@ -4,7 +4,7 @@ image:
 simplestream:
   requirements:
   - requirements:
-      secure_boot: false
+      secureboot: false
 
 source:
   downloader: gentoo-http

--- a/images/nixos.yaml
+++ b/images/nixos.yaml
@@ -5,7 +5,7 @@ simplestream:
   distro_name: NixOS
   requirements:
   - requirements:
-      secure_boot: false
+      secureboot: false
 
 source:
   downloader: nixos-http


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/13409

Also, fix/improve a few things along the way.

It's too bad that `bin/test-image` cannot consult the image requirements otherwise it would have been possible to look if the image being tested is not going to work with `secureboot`. For now I hardcoded the known incompatible distros but if @MusicDin you know better, please let me know!