### PR TITLE
tests/container-copy: wait for host time to stabilize before creating VM

### DIFF
--- a/tests/container-copy
+++ b/tests/container-copy
@@ -18,6 +18,12 @@ loopdev="$(losetup --show --find "${loopimg}")"
 # Begin Test.
 set -x
 
+echo "==> Wait for the host time to be synchronized with NTP"
+for _ in $(seq 6); do
+    [ "$(timedatectl show --property=NTPSynchronized --value)" = "yes" ] && break
+    sleep 10
+done
+
 echo "==> Launch a VM which will be the target of the copy"
 lxc launch "${IMAGE}" target --vm
 waitInstanceBooted target

--- a/tests/container-copy
+++ b/tests/container-copy
@@ -30,8 +30,7 @@ waitInstanceBooted target
 
 echo "==> Setup LXD on the target VM"
 lxc exec target -- snap install lxd --channel "${LXD_SNAP_CHANNEL}"
-lxc exec target -- lxd init --auto
-lxc exec target -- lxc config set core.https_address=:8443
+lxc exec target -- lxd init --auto --network-address "[::]" --network-port "8443"
 
 echo "==> Wait for the target VM time to be synchronized with NTP"
 for _ in $(seq 6); do


### PR DESCRIPTION
This is attempting to avoid having the guest's time being behind the host:

```
==> Add the target VM as a remote LXD
++ lxc exec target -- lxc config trust add --name host --quiet
+ token=eyJjbGllbnRfbmFtZSI6Imhvc3QiLCJmaW5nZXJwcmludCI6IjY0NjRkZGY3MWIyZTZlZjRhNDBlYTZmY2ZlNzY5Nzg2Zjk0NDc5OTIyYmM4ZWM1OWU0YmMzZmJjZjEzZTM3YTAiLCJhZGRyZXNzZXMiOlsiMTAuMTAyLjExLjEzNTo4NDQzIiwiW2ZkNDI6OTMxODo0YWQ0OmRiY2Q6MjE2OjNlZmY6ZmUxZDo5ZTkyXTo4NDQzIiwiMTAuMTA3LjI1MC4xOjg0NDMiLCJbZmQ0MjplZDc4OjcyYTI6OGRjMzo6MV06ODQ0MyJdLCJzZWNyZXQiOiI2ZTIzOTcxMmRjZGY0YzEzZmZmYWZhOWI5ZTkyNDdlNGZhZjE2MTQ2YzFjMmZhYTE2ZjIzZTllM2ZmNzZlN2NjIiwiZXhwaXJlc19hdCI6IjAwMDEtMDEtMDFUMDA6MDA6MDBaIn0=
+ lxc remote add target eyJjbGllbnRfbmFtZSI6Imhvc3QiLCJmaW5nZXJwcmludCI6IjY0NjRkZGY3MWIyZTZlZjRhNDBlYTZmY2ZlNzY5Nzg2Zjk0NDc5OTIyYmM4ZWM1OWU0YmMzZmJjZjEzZTM3YTAiLCJhZGRyZXNzZXMiOlsiMTAuMTAyLjExLjEzNTo4NDQzIiwiW2ZkNDI6OTMxODo0YWQ0OmRiY2Q6MjE2OjNlZmY6ZmUxZDo5ZTkyXTo4NDQzIiwiMTAuMTA3LjI1MC4xOjg0NDMiLCJbZmQ0MjplZDc4OjcyYTI6OGRjMzo6MV06ODQ0MyJdLCJzZWNyZXQiOiI2ZTIzOTcxMmRjZGY0YzEzZmZmYWZhOWI5ZTkyNDdlNGZhZjE2MTQ2YzFjMmZhYTE2ZjIzZTllM2ZmNzZlN2NjIiwiZXhwaXJlc19hdCI6IjAwMDEtMDEtMDFUMDA6MDA6MDBaIn0= --accept-certificate
Generating a client certificate. This may take a minute...
Error: Failed to create certificate: The provided certificate isn't valid yet
```

In there ^, the host creates a certificate with a `Not Before` time that is in the future from a guest's point of view.


This is a workaround for https://github.com/canonical/lxd/issues/13388. If that workaround is not enough, another workaround would be to create pre-create the client cert, wait a while and then asking/use a join token to then inject the then "old" certificate.