### PR TITLE
Revert "github/workflows: Disable Debian Sid"

### DIFF
--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -24,7 +24,7 @@ jobs:
         release:
           - buster
           - bullseye
-          #- sid
+          - sid
           - bookworm
           - trixie
         variant:


### PR DESCRIPTION
We know Debian Sid doesn't work ATM but the server team is busy merging stuff from Debian into Ubuntu Oracular. Having the ability to launch Sid instances would help them.

I think we should be merging it now even if known broken because eventually it will start working on its own. Until it does, we'll also have traces of where it fails.