### PR TITLE
bin/build-distro: display debootstrap.log on failure/exit

### DIFF
--- a/bin/build-distro
+++ b/bin/build-distro
@@ -14,6 +14,17 @@ TIMEOUT=${4}
 TARGET=${5}
 shift 5
 
+debug_logs() {
+    set +e
+    if [ -e "${TARGET}/rootfs/debootstrap/debootstrap.log" ]; then
+        echo
+        echo "Debootstrap log:"
+        cat "${TARGET}/rootfs/debootstrap/debootstrap.log"
+    fi
+}
+
+trap debug_logs EXIT HUP INT TERM
+
 # Setup build directory.
 CACHE_DIR="${TARGET}/cache"
 mkdir -p "${CACHE_DIR}"


### PR DESCRIPTION
This should be useful when Debian based distros fail to build. Here it is in action with Debian Sid:

```
# ./bin/build-distro images/debian.yaml amd64 container 1800 "${HOME}/build" -o image.architecture=amd64 -o image.release=sid -o image.variant=default -o source.url="https://deb.debian.org/debian"
...
I: Extracting util-linux...
I: Extracting zlib1g...
W: Upgrading non-merged-/usr environments post-bookworm is unsupported. Only do this for CI/QA infrastructure that will be re-bootstrapped rather than upgraded.
W: Failure trying to run: chroot "/root/build/rootfs" /bin/true
W: See /root/build/rootfs/debootstrap/debootstrap.log for details
Error: Error while downloading source: Failed to run "debootstrap": exit status 1
ERROR  [2024-05-03T16:11:44Z] Failed running imagebuilder                   err="Error while downloading source: Failed to run \"debootstrap\": exit status 1"
INFO   [2024-05-03T16:11:44Z] Removing cache directory  
                   
Debootstrap log:
2024-05-03 16:10:21 URL:https://deb.debian.org/debian/dists/sid/InRelease [198381/198381] -> "/root/build/rootfs/var/lib/apt/lists/partial/deb.debian.org_debian_dists_sid_InRelease" [1]
gpgv: Signature made Fri May  3 14:16:13 2024 UTC
gpgv:                using RSA key A7236886F3CCCAAD148A27F80E98404D386FA1D9
gpgv: Can't check signature: No public key
gpgv: Signature made Fri May  3 14:16:14 2024 UTC
gpgv:                using RSA key 4CB50190207B4758A3F73A796ED0E7B82643E131
gpgv: Good signature from "Debian Archive Automatic Signing Key (12/bookworm) <ftpmaster@debian.org>"
2024-05-03 16:10:24 URL:https://deb.debian.org/debian/dists/sid/main/binary-amd64/by-hash/SHA256/81d95018e90488deb9119f5b06b40fc6cfd8cc8c6e8919949650656ff5e2b5f4 [9847688/9847688] -> "/root/build/rootfs/var/lib/apt/lists/partial/deb.debian.org_debian_dists_sid_main_binary-amd64_Packages.xz" [1]
...
2024-05-03 16:11:41 URL:https://deb.debian.org/debian/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1_amd64.deb [87580/87580] -> "/root/build/rootfs//var/cache/apt/archives/partial/zlib1g_1%3a1.3.dfsg-3.1_amd64.deb" [1]
chroot: failed to run command '/bin/true': No such file or directory

```