### PR TITLE
Add tests for handling disk devices with long names

### DIFF
--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -109,6 +109,19 @@ waitInstanceReady v1
 lxc exec v1 -- ls -l /mnt/foo1
 lxc stop -f v1
 
+# Check adding a disk to a vm with a long name to test possible problems with long socket paths or long qemu device tags
+LONG_DEVICE_NAME="device-with-very-long-name-for-long-qemu-property-handling-test"
+
+lxc init "${IMAGE}" v2 --vm
+lxc config device add v2 "${LONG_DEVICE_NAME}" disk source="${testRoot}/allowed1" path="/mnt/bar1"
+lxc start v2
+waitInstanceReady v2
+lxc exec v2 -- mountpoint /mnt/bar
+lxc config device remove v2 "${LONG_DEVICE_NAME}"
+lxc config device add v2 "${LONG_DEVICE_NAME}" disk source="${testRoot}/allowed1" path="/mnt/bar2" # Test hotplugging as well
+lxc exec v2 -- mountpoint /mnt/bar
+lxc delete -f v2
+
 # Check adding a disk with a source path that is allowed that symlinks to another allowed source path isn't
 # allowed at start time.
 lxc config device set v1 d1 source="${testRoot}/allowed1/not-allowed2"


### PR DESCRIPTION
Devices with long names can cause some problems due to socket paths or device tags that include those names being too long, resulting in errors from QEMU. See [#13320](https://github.com/canonical/lxd/pull/13320) and [#15516](https://github.com/canonical/lxd/pull/13516).