### PR TITLE
github: drop alpine 3.16 (EOL) and add 3.20

### DIFF
--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -25,6 +25,7 @@ jobs:
           - "3.17"
           - "3.18"
           - "3.19"
+          - "3.20"
           - "edge"
         variant:
           - default

--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - "3.16"
           - "3.17"
           - "3.18"
           - "3.19"


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.20.0-released.html

https://alpinelinux.org/releases/ shows 3.16 EOL on 2024-05-23