### PR TITLE
Add tests for TPM usage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,6 +98,7 @@ jobs:
           - "storage-vm lvm-thin"
           - "storage-vm zfs"
           - storage-volumes-vm
+          - tpm-vm
           - vm-nesting
         exclude:
           - test: efi-vars-editor-vm # not compatible with 5.0/*

--- a/tests/tpm-vm
+++ b/tests/tpm-vm
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+# Install LXD
+install_lxd
+
+# Configure LXD
+lxd init --auto
+
+IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"
+vmName="test-vm"
+
+# Launch test instance
+lxc init "${IMAGE}" "${vmName}" --vm
+
+echo "==> Try starting a VM with two TPM devices"
+lxc config device add "${vmName}" tpm1 tpm
+lxc config device add "${vmName}" tpm2 tpm
+! lxc start "${vmName}" || false
+
+echo "==> Starting VM with TPM"
+lxc config device remove "${vmName}" tpm2
+lxc start "${vmName}"
+waitInstanceReady "${vmName}"
+
+echo "==> Check if TPM files are present"
+lxc exec "${vmName}" -- stat /dev/tpm0
+lxc exec "${vmName}" -- stat /dev/tpmrm0
+
+echo "==> Try removing TPM from a running VM"
+! lxc config device remove "${vmName}" tpm1 || false
+lxc exec "${vmName}" -- stat /dev/tpm0
+lxc exec "${vmName}" -- stat /dev/tpmrm0
+
+echo "==> Stopping VM and removing TPM"
+lxc stop "${vmName}" --force
+lxc config device remove "${vmName}" tpm1
+
+echo "==> Check if TPM was indeed removed"
+lxc start "${vmName}"
+waitInstanceReady "${vmName}"
+! lxc exec "${vmName}" -- stat /dev/tpm0 || false
+! lxc exec "${vmName}" -- stat /dev/tpmrm0 || false
+lxc stop "${vmName}" --force

--- a/tests/tpm-vm
+++ b/tests/tpm-vm
@@ -42,3 +42,13 @@ waitInstanceReady "${vmName}"
 ! lxc exec "${vmName}" -- stat /dev/tpm0 || false
 ! lxc exec "${vmName}" -- stat /dev/tpmrm0 || false
 lxc stop "${vmName}" --force
+
+# TPM names are included on the swtpm socket path and long socket paths can cause problems if not handled correctly.
+echo "==> Test handling TPMs with long names"
+longName="tpm-device-with-long-name-for-testing"
+lxc config device add "${vmName}" "${longName}" tpm
+lxc start "${vmName}"
+waitInstanceReady "${vmName}"
+lxc exec "${vmName}" -- stat /dev/tpm0
+lxc exec "${vmName}" -- stat /dev/tpmrm0
+lxc delete "${vmName}" --force


### PR DESCRIPTION
Adding tests for basic TPM usage on VMs, with included tests for handling TPMs with long names (see [#13320](https://github.com/canonical/lxd/pull/13320))