### PR TITLE
github: switch to using 24.04 on CI runners

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   commits:
     name: Branch target
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check branch target
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,6 +148,18 @@ jobs:
           sudo ip link delete docker0
           sudo nft flush ruleset
 
+      - name: Remove needrestart
+        run: |
+          # XXX: workaround https://bugs.launchpad.net/ubuntu/+source/needrestart/+bug/2067800
+          #      needrestart restarting runner-provisioner.service causes an immediate job failure:
+          #
+          #Restarting services...
+          # /etc/needrestart/restart.d/systemd-manager
+          # systemctl restart packagekit.service php8.3-fpm.service runner-provisioner.service systemd-journald.service systemd-networkd.service systemd-resolved.service systemd-udevd.service udisks2.service walinuxagent.service
+          #Terminated
+          #++ cleanup
+          sudo apt-get autopurge -y needrestart
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,11 +70,12 @@ jobs:
   system-tests:
     env:
       PURGE_LXD: "1"
-    name: ${{ matrix.test }} (${{ matrix.track }})
-    runs-on: ubuntu-24.04
+    name: ${{ matrix.test }} (${{ matrix.track }} - ${{ matrix.os }})
+    runs-on: ubuntu-${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [22.04, 24.04]
         track: ${{ fromJSON(inputs.snap-tracks || '["latest/edge", "5.21/edge", "5.0/edge"]') }}
         test:
           - cgroup
@@ -105,6 +106,10 @@ jobs:
             track: "5.0/edge"
           - test: storage-buckets  # waiting for integration with microceph
           - test: "storage-vm ceph" # waiting for integration with microceph
+          - track: "5.0/edge"
+            os: "24.04"
+          - track: "latest/edge"
+            os: "22.04"
 
     steps:
       - name: Performance tuning

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ defaults:
 jobs:
   code-tests:
     name: Code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
     env:
       PURGE_LXD: "1"
     name: ${{ matrix.test }} (${{ matrix.track }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Remove docker
         run: |
           set -eux
-          sudo apt-get autopurge -y containerd.io moby-containerd docker docker-ce podman uidmap
+          sudo apt-get autopurge -y containerd.io docker-ce podman uidmap
           sudo ip link delete docker0
           sudo nft flush ruleset
 

--- a/tests/docker
+++ b/tests/docker
@@ -39,6 +39,15 @@ for BIN in docker dockerd docker-init docker-proxy; do
         chmod +x "/usr/bin/\${BIN}"
 done
 
+# XXX: Workaround Apparmor/kernel bug: https://bugs.launchpad.net/bugs/2067900
+if [ -e /etc/apparmor.d/runc ]; then
+  cat << EOF2 > /etc/apparmor.d/local/runc
+# Workaround https://bugs.launchpad.net/bugs/2067900
+  pivot_root,
+EOF2
+  apparmor_parser -rTW /etc/apparmor.d/runc
+fi
+
 unset https_proxy
 
 # Start docker again

--- a/tests/interception
+++ b/tests/interception
@@ -112,6 +112,18 @@ if hasNeededAPIExtension container_syscall_intercept_finit_module; then
     # upload module file into the container
     lxc file push "${MODULE_PATH}" "c1/root/"
 
+    # Ubuntu 23.10+ ships kernel modules individually compressed to speed up
+    # boot and initramfs generation
+    # (https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2028568)
+    # XXX: This compression seems to prevent proper parsing by the `container_syscall_intercept_finit_module` feature
+    #      resulting in `Operation not permitted` error
+    if echo "${MODULE_FILE_NAME}" | grep -q "\.zst$"; then
+        lxc exec c1 -- apt-get update -qq
+        lxc exec c1 -- apt-get install --no-install-recommends -y zstd
+        lxc exec c1 -- unzstd "/root/${MODULE_FILE_NAME}"
+        MODULE_FILE_NAME="$(basename "${MODULE_PATH}" .zst)"
+    fi
+
     # negative case 1 (feature is not enabled)
     ! lxc exec c1 -- insmod "/root/${MODULE_FILE_NAME}" || false
 


### PR DESCRIPTION
Current issues with the PR:

* The workaround for needrestart should be reported on LP: https://bugs.launchpad.net/ubuntu/+source/needrestart/+bug/2067800
* `tests/cluster` fails on 24.04 due to the kernel temporarily missing `fan` support (https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2064508)
* `tests/docker` required a local workaround Apparmor rule to allow `pivot_root` (https://github.com/canonical/lxd/issues/13389)
* `tests/interception` fail likely due to having `.ko.zst` compressed (working on a potential fix)
* `tests/storage-vm zfs` fails due to `zfs` missing the rounding fix by @MggMuggins
* `tests/tpm` is failing due to overly long path (patch to be merged/backported, @hamistao is aware of it)