### PR TITLE
alpine: Build edge based on latest release

### DIFF
--- a/images/alpine.yaml
+++ b/images/alpine.yaml
@@ -8,7 +8,7 @@ simplestream:
 
 source:
   downloader: alpinelinux-http
-  same_as: 3.12
+  same_as: 3.20
   url: https://mirror.csclub.uwaterloo.ca/alpine/
   keys:
   # 0482D84022F52DF1C4E7CD43293ACD0907D9495A


### PR DESCRIPTION
Build Alpine edge based on `3.20` instead of `3.12` development branch.

Fixes https://github.com/canonical/lxd/issues/13414