### PR TITLE
github: Fedora 38 reached EOL on 2024-05-21

### DIFF
--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 38
           - 39
           - 40
         variant:


### PR DESCRIPTION
https://discussion.fedoraproject.org/t/f38-is-end-of-life/117727