### PR TITLE
Tests: Add exception for PowerFlex stateful migration checks

### DIFF
--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -636,21 +636,31 @@ for poolDriver in $poolDriverList; do
                 lxc config unset instances.migration.stateful
 
                 echo "==> Checking start / stop operations with root size.state being unset"
-                # We should be able to start a VM with migration.stateful=true eventhough the root `size.state` config is unset
-                lxc launch "${IMAGE}" v1 --vm --config migration.stateful=true -s "${poolName}"
+                # We should be able to start a VM with migration.stateful=true eventhough the root `size.state` config is unset.
+                if [ "${poolDriver}" != "powerflex" ]; then
+                        lxc launch "${IMAGE}" v1 --vm --config migration.stateful=true -s "${poolName}"
+                else
+                        # For PowerFlex use more memory than the default size of the VM's config drive which is 8GiB.
+                        lxc launch "${IMAGE}" v1 --vm --config migration.stateful=true --config limits.memory=9GiB -s "${poolName}"
+                fi
                 waitInstanceReady v1
-                # However, we should not be able to statefully stop the VM
+                # However, we should not be able to statefully stop the VM.
                 ! lxc stop v1 --stateful || false
-                # But we should be able to change the root size.state config without stopping the VM
-                lxc config device set v1 root size.state=2GiB
+                # But we should be able to change the root size.state config without stopping the VM.
+                if [ "${poolDriver}" != "powerflex" ]; then
+                        lxc config device set v1 root size.state=2GiB
+                else
+                        # For PowerFlex set the size.state to the smallest next possible number which is 16GiB.
+                        lxc config device set v1 root size.state=16GiB
+                fi
                 # And then we should be able to statefully stop the VM.
-                # But before, let's register the boot_id to check that it has not changed after a stateful stop / start
+                # But before, let's register the boot_id to check that it has not changed after a stateful stop / start.
                 boot_id=$(lxc exec v1 -- cat /proc/sys/kernel/random/boot_id)
                 lxc stop v1 --stateful
-                # And then we should be able to statefully start the VM again
+                # And then we should be able to statefully start the VM again.
                 lxc start v1
                 waitInstanceReady v1
-                # And the boot_id should not have changed
+                # And the boot_id should not have changed.
                 if [ "$(lxc exec v1 -- cat /proc/sys/kernel/random/boot_id)" != "${boot_id}" ]; then
                         echo "==> Boot ID changed after stateful stop / start"
                         false


### PR DESCRIPTION
The default size of the config drive for PowerFlex backed VMs is 8GiB. This requires setting a higher memory value for the VM to trigger the error if `size.state` is too small.