### PR TITLE
bin: Allow sideloading of lxd binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ export PURGE_LXD=1
 
 Note: if you need to run tests on temporary machines, [Testflinger reservations](https://docs.google.com/document/d/11Kot68mnBY9Wq9DXRzTVrKpx5cMkkhBC5RrM51eyybY) might be useful.
 
+To test a custom build of LXD, you can set the `LXD_SIDELOAD_PATH` environment variable.
+This will be copied to `/var/snap/lxd/common/lxd.debug` and the daemon will be reloaded before the test run.
+
+```
+export LXD_SIDELOAD_PATH=/tmp/lxd
+./bin/local-run tests/interception latest/edge
+```
+
 
 # Running tests on OpenStack (ProdStack)
 

--- a/bin/helpers
+++ b/bin/helpers
@@ -128,6 +128,12 @@ install_lxd() (
     # on first invocation
     mkdir -p ~/snap/lxd/common/config/
     touch ~/snap/lxd/common/config/config.yml
+
+    if [ -n "${LXD_SIDELOAD_PATH:-}" ]; then
+        systemctl stop snap.lxd.daemon
+        cp "${LXD_SIDELOAD_PATH}" /var/snap/lxd/common/lxd.debug
+        systemctl start snap.lxd.daemon
+    fi
 )
 
 # hasNeededAPIExtension: check if LXD supports the needed extension.


### PR DESCRIPTION
Adds a new environment variable `ENABLE_SIDELOADING` which stops the LXD daemon, then starts it again when the user presses enter. This allows time for loading a custom build.

I found this useful in my local testing.