### PR TITLE
CI tweaks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,8 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # XXX: scheduled runs should not cancel manually triggered ones
+  cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
 defaults:
   run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '38 9 * * *'
+    - cron: '38 6 * * *'
   workflow_dispatch:
     inputs:
       snap-tracks:

--- a/tests/cpu-vm
+++ b/tests/cpu-vm
@@ -19,7 +19,7 @@ systemctl restart snap.lxd.daemon.service
 lxc network create lxdbr0
 lxc profile device add default eth0 nic network=lxdbr0
 
-IMAGE="${TEST_IMG:-ubuntu-daily:24.04}"
+IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"
 
 poolName="vmpool$$"
 poolDriver=dir

--- a/tests/cpu-vm
+++ b/tests/cpu-vm
@@ -47,15 +47,15 @@ lxc info v1
 
 # Get number of CPUs
 # shellcheck disable=SC2010
-cpuCount="$(ls /sys/devices/system/cpu | grep -Ec 'cpu[[:digit:]]+')"
+cpuCount="$(ls /sys/devices/system/cpu | grep -xEc 'cpu[[:digit:]]+')"
 
 # VMs should have only 1 CPU per default
-[ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -Ec 'cpu[[:digit:]]+')" -eq "1" ]
+[ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -xEc 'cpu[[:digit:]]+')" -eq "1" ]
 
 # Set valid CPU limits (low to high)
 for i in $(seq 2 "${cpuCount}"); do
   lxc config set v1 limits.cpu="${i}"
-  [ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -Ec 'cpu[[:digit:]]+')" -eq "${i}" ]
+  [ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -xEc 'cpu[[:digit:]]+')" -eq "${i}" ]
 done
 
 # Try setting more CPUs than available
@@ -64,7 +64,7 @@ done
 # Set valid CPU limits (high to low)
 for i in $(seq "${cpuCount}" -1 1); do
   lxc config set v1 limits.cpu="${i}"
-  [ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -Ec 'cpu[[:digit:]]+')" -eq "${i}" ]
+  [ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -xEc 'cpu[[:digit:]]+')" -eq "${i}" ]
 done
 
 # Try doing pinning while VM is running (shouldn't work)
@@ -72,7 +72,7 @@ done
 
 # Set max CPU count
 lxc config set v1 limits.cpu="${cpuCount}"
-[ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -Ec 'cpu[[:digit:]]+')" -eq "${cpuCount}" ]
+[ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -xEc 'cpu[[:digit:]]+')" -eq "${cpuCount}" ]
 
 # check that CPU affinity is automatically set if feature present
 QEMU_PID=$(lxc info v1 | awk '/^PID:/ {print $2}')
@@ -97,7 +97,7 @@ fi
 lxc config unset v1 limits.cpu
 
 # Unsetting the limit should leave the VM with 1 CPU
-[ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -Ec 'cpu[[:digit:]]+')" -eq "1" ]
+[ "$(lxc exec v1 -- ls /sys/devices/system/cpu | grep -xEc 'cpu[[:digit:]]+')" -eq "1" ]
 
 echo "==> Stopping and deleting ephemeral VM"
 # Stop VM and check its deleted.

--- a/tests/cpu-vm
+++ b/tests/cpu-vm
@@ -78,7 +78,7 @@ lxc config set v1 limits.cpu="${cpuCount}"
 QEMU_PID=$(lxc info v1 | awk '/^PID:/ {print $2}')
 if journalctl --quiet --no-hostname --no-pager --boot=0 --unit=snap.lxd.daemon.service | grep "Scheduler: virtual-machine"; then
   # Check that there are processes with pinning set
-  # It will be shown like this:
+  # It will be shown like this (for limits.cpu=2):
   # pid 2894's current affinity list: 6
   # pid 2895's current affinity list: 8
   # pid 2897's current affinity list: 0-15


### PR DESCRIPTION
@tomponline I tried adding a `sleep 3` prior to checking `taskset` output but that didn't fair any better. @mihalicyn ideally the `lxc config set <instance> limits.cpu=X` should be waiting for the CPU affinity changes to be done before returning.

@tomponline this should improve the scheduling of the tests and avoid scheduled runs from cancelling manually triggered ones.