### PR TITLE
cpu-vm: relax cpu pinning check a bit

### DIFF
--- a/tests/cpu-vm
+++ b/tests/cpu-vm
@@ -85,8 +85,8 @@ if journalctl --quiet --no-hostname --no-pager --boot=0 --unit=snap.lxd.daemon.s
   # pid 2898's current affinity list: 0-15
   # pid 2899's current affinity list: 0-15
   # 2894 and 2895 have affinity set, while others don't
-  PINNED_VCPU_NUM=$(taskset --cpu-list -a -p "${QEMU_PID}" | grep -cE ':\s+[0-9]+$')
-  [ "${PINNED_VCPU_NUM}" = "$(lxc config get v1 limits.cpu)" ]
+  PINNED_THREADS_NUM=$(taskset --cpu-list -a -p "${QEMU_PID}" | grep -cE ':\s+[0-9]+$')
+  [ "${PINNED_THREADS_NUM}" -ge "$(lxc config get v1 limits.cpu)" ]
 else
   # check that there is no pinning set
   ! taskset --cpu-list -a -p "${QEMU_PID}" | grep -E ':\s+[0-9]+$' || false


### PR DESCRIPTION
It was discovered, that current check, while being correct in theory works really bad in practice. Because QEMU sometimes spawns additional temporary threads from an actual vCPU threads which leads to the situation when we have more threads with pinning applied than vCPU number. Let's relax our check a bit and check for "greater than" and not for the equality.

https://warthogs.atlassian.net/browse/LXD-1200