### PR TITLE
revert: bin/test-image: use isSystemdClean() helper function

### DIFF
--- a/bin/test-image
+++ b/bin/test-image
@@ -193,8 +193,12 @@ for url in $(lxc query "/1.0/instances" | jq -r .[] | grep "${TEST_IMAGE}"); do
 
     # Systemd cleanliness.
     if lxc exec "${name}" -- test -d /run/systemd/system/; then
-        if ! isSystemdClean "${name}"; then
+        if lxc exec "${name}" -- systemctl --failed 2>&1 | grep -qwF 'failed'; then
             echo "===> FAIL: systemd clean: ${name}"
+
+            # Show the systemd failures.
+            echo "===> DEBUG: systemd failed: ${name}"
+            lxc exec "${name}" -- systemctl --failed
             FAIL=1
         else
             echo "===> PASS: systemd clean: ${name}"


### PR DESCRIPTION
Commit in #185 broke many image tests (especially older releases) by using `isSystemdClean` function. Function also uses `systemctl --wait` flag which is not supported on older releases. 