### PR TITLE
tests/container-copy: stop trying to wait for host/VM time to be sync'ed

### DIFF
--- a/tests/container-copy
+++ b/tests/container-copy
@@ -18,12 +18,6 @@ loopdev="$(losetup --show --find "${loopimg}")"
 # Begin Test.
 set -x
 
-echo "==> Wait for the host time to be synchronized with NTP"
-for _ in $(seq 6); do
-    [ "$(timedatectl show --property=NTPSynchronized --value)" = "yes" ] && break
-    sleep 10
-done
-
 echo "==> Launch a VM which will be the target of the copy"
 lxc launch "${IMAGE}" target --vm
 waitInstanceBooted target
@@ -31,12 +25,6 @@ waitInstanceBooted target
 echo "==> Setup LXD on the target VM"
 lxc exec target -- snap install lxd --channel "${LXD_SNAP_CHANNEL}"
 lxc exec target -- lxd init --auto --network-address "[::]" --network-port "8443"
-
-echo "==> Wait for the target VM time to be synchronized with NTP"
-for _ in $(seq 6); do
-    [ "$(lxc exec target -- timedatectl show --property=NTPSynchronized --value)" = "yes" ] && break
-    sleep 10
-done
 
 echo "==> Add the target VM as a remote LXD"
 token="$(lxc exec target -- lxc config trust add --name host --quiet)"


### PR DESCRIPTION
In theory, https://github.com/canonical/lxd/pull/13606 should be a better way to fix this.