### PR TITLE
tests/storage-buckets: enable test except for ceph pools

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,6 @@ jobs:
             os: "24.04"
           - test: efi-vars-editor-vm # not compatible with 5.0/*
             track: "5.0/edge"
-          - test: storage-buckets  # waiting for integration with microceph
           - test: "storage-vm ceph" # waiting for integration with microceph
           - track: "5.0/edge"
             os: "24.04"

--- a/tests/storage-buckets
+++ b/tests/storage-buckets
@@ -30,8 +30,8 @@ fi
 poolDriverList="${1:-dir btrfs lvm lvm-thin zfs ceph}"
 
 if echo "${poolDriverList}" | grep -qwF "ceph"; then
+  # XXX: LXD will be reloaded further down
   snap set lxd ceph.external=true
-  lxd waitready --timeout=300
 
   # Install dependencies
   install_deps ceph-common

--- a/tests/storage-buckets
+++ b/tests/storage-buckets
@@ -43,11 +43,11 @@ mkdir -p /opt/minio
 
 # Download the minio server.
 curl -sSfL "https://dl.min.io/server/minio/release/linux-${arch}/minio" --output "/opt/minio/minio"
-chmod +x "opt/minio/minio"
+chmod +x "/opt/minio/minio"
 
 # Also grab the latest minio client to maintain compatibility with the server.
 curl -sSfL "https://dl.min.io/client/mc/release/linux-${arch}/mc" --output "/opt/minio/mc"
-chmod +x "opt/minio/mc"
+chmod +x "/opt/minio/mc"
 
 # Set the snap config key for minio and reload LXD to have it take effect.
 snap set lxd minio.path=/opt/minio

--- a/tests/storage-buckets
+++ b/tests/storage-buckets
@@ -13,7 +13,9 @@ fi
 
 # Grab the architecture so we can install the correct pre-built minio.
 arch="$(uname -m)"
-if [ "${arch}" = "aarch64" ]; then
+if [ "${arch}" = "x86_64" ]; then
+  arch="amd64"
+elif [ "${arch}" = "aarch64" ]; then
   arch="arm64"
 elif [ "${arch}" = "ppc64el" ]; then
   arch="ppc64le"

--- a/tests/storage-buckets
+++ b/tests/storage-buckets
@@ -30,6 +30,11 @@ fi
 poolDriverList="${1:-dir btrfs lvm lvm-thin zfs ceph}"
 
 if echo "${poolDriverList}" | grep -qwF "ceph"; then
+  echo "::warning::Skipping test on ceph until we can integrate with microceph"
+  poolDriverList="$(echo "${poolDriverList}" | sed 's/ \?\bceph\b//')"
+fi
+
+if echo "${poolDriverList}" | grep -qwF "ceph"; then
   # XXX: LXD will be reloaded further down
   snap set lxd ceph.external=true
 

--- a/tests/storage-buckets
+++ b/tests/storage-buckets
@@ -34,8 +34,7 @@ if echo "${poolDriverList}" | grep -qwF "ceph"; then
   lxd waitready --timeout=300
 
   # Install dependencies
-  apt-get update
-  apt-get install --no-install-recommends --yes ceph-common
+  install_deps ceph-common
 fi
 
 # Clean up the build dir in case it hung around from a failed test.


### PR DESCRIPTION
https://dl.min.io/server/minio/release/linux-amd64/minio works but not https://dl.min.io/server/minio/release/linux-x86_64/minio

This test is still inactive (in the excluded section of the testing matrix) because it's waiting on the integration of microceph.