### PR TITLE
Disable secureboot for openeuler

### DIFF
--- a/bin/test-image
+++ b/bin/test-image
@@ -76,7 +76,7 @@ if [ "${TYPE}" = "vm" ]; then
 
     # Some distros don't support secure boot.
     case "${DISTRO}" in
-        alpine|archlinux|gentoo|nixos)
+        alpine|archlinux|gentoo|nixos|openeuler)
             lxc config set "${TEST_IMAGE}" security.secureboot=false
             ;;
     esac

--- a/images/openeuler.yaml
+++ b/images/openeuler.yaml
@@ -5,6 +5,9 @@ image:
 
 simplestream:
   distro_name: openEuler
+  requirements:
+  - requirements:
+      secureboot: false
 
 source:
   downloader: openeuler-http


### PR DESCRIPTION
openEuler VMs do not start if secureboot is enabled.

Passing build: https://github.com/MusicDin/lxd-ci/actions/runs/9586102046/job/26433364126

Fixes https://github.com/canonical/lxd/issues/13636