### PR TITLE
github: extent test matrix to 4.0/edge and 20.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,8 +76,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [22.04, 24.04]
-        track: ${{ fromJSON(inputs.snap-tracks || '["latest/edge", "5.21/edge", "5.0/edge"]') }}
+        os: [20.04, 22.04, 24.04]
+        track: ${{ fromJSON(inputs.snap-tracks || '["latest/edge", "5.21/edge", "5.0/edge", "4.0/edge"]') }}
         test:
           - cgroup
           - cluster

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,8 @@ jobs:
           - test: cluster  # fan is not yet working on 24.04 kernel: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2064508
             os: "24.04"
           # not compatible with 4.0/*
+          - test: container-copy
+            track: "4.0/edge"
           - test: cpu-vm
             track: "4.0/edge"
           - test: devlxd-vm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,7 +175,7 @@ jobs:
           echo "force-unsafe-io" | sudo tee /etc/dpkg/dpkg.cfg.d/force-unsafe-io
 
       - name: Reclaim some space (storage tests only)
-        if: ${{ startsWith(matrix.test, 'storage') }}
+        if: ${{ startsWith(matrix.test, 'storage') || matrix.test == 'vm-nesting' }}
         run: |
           set -eux
           df -h

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,6 +127,10 @@ jobs:
           - test: storage-buckets  # not compatible with 4.0/*
             track: "4.0/stable"
           - test: "storage-vm ceph"  # waiting for integration with microceph
+          - track: "4.0/edge"
+            os: "24.04"
+          - track: "4.0/stable"
+            os: "24.04"
           - track: "5.0/edge"
             os: "24.04"
           - track: "5.0/stable"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,6 +135,8 @@ jobs:
             track: "4.0/edge"
           - test: "storage-vm zfs"
             track: "4.0/edge"
+          - test: tpm-vm
+            track: "4.0/edge"
           # not compatible with 5.0/*
           - test: efi-vars-editor-vm  # not compatible with 5.0/*
             track: "5.0/edge"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,6 +117,9 @@ jobs:
             track: "4.0/edge"
           - test: efi-vars-editor-vm
             track: "4.0/edge"
+          - test: network-bridge-firewall
+            os: 20.04
+            track: "4.0/edge"
           - test: network-ovn
             track: "4.0/edge"
           - test: storage-buckets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,6 +135,8 @@ jobs:
             track: "4.0/edge"
           - test: "storage-vm zfs"
             track: "4.0/edge"
+          - test: storage-volumes-vm
+            track: "4.0/edge"
           - test: tpm-vm
             track: "4.0/edge"
           # not compatible with 5.0/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,15 +110,31 @@ jobs:
         exclude:
           - test: cluster  # fan is not yet working on 24.04 kernel: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2064508
             os: "24.04"
-          - test: devlxd-vm  # not compatible with 4.0/*
+          # not compatible with 4.0/*
+          - test: devlxd-vm
             track: "4.0/edge"
+          - test: efi-vars-editor-vm
+            track: "4.0/edge"
+          - test: storage-buckets
+            track: "4.0/edge"
+          - test: "storage-vm dir"
+            track: "4.0/edge"
+          - test: "storage-vm btrfs"
+            track: "4.0/edge"
+          - test: "storage-vm ceph"
+            track: "4.0/edge"
+          - test: "storage-vm lvm"
+            track: "4.0/edge"
+          - test: "storage-vm lvm-thin"
+            track: "4.0/edge"
+          - test: "storage-vm zfs"
+            track: "4.0/edge"
+          # not compatible with 5.0/*
           - test: efi-vars-editor-vm  # not compatible with 5.0/*
             track: "5.0/edge"
-          - test: efi-vars-editor-vm  # not compatible with 4.0/*
-            track: "4.0/edge"
-          - test: storage-buckets  # not compatible with 4.0/*
-            track: "4.0/edge"
-          - test: "storage-vm ceph"  # waiting for integration with microceph
+          # waiting for integration with microceph
+          - test: "storage-vm ceph"
+          # skip track/os combinaisons that are too far appart
           - track: "4.0/edge"
             os: "24.04"
           - track: "5.0/edge"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,7 +158,7 @@ jobs:
           set -eux
           sudo apt-get autopurge -y containerd.io docker-ce podman uidmap
           sudo ip link delete docker0
-          sudo nft flush ruleset
+          sudo nft flush ruleset || sudo iptables -I DOCKER-USER -j ACCEPT
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,8 +135,18 @@ jobs:
             os: "24.04"
           - track: "5.0/stable"
             os: "24.04"
+          - track: "5.0/edge"
+            os: "20.04"
+          - track: "5.21/edge"
+            os: "20.04"
+          - track: "5.21/stable"
+            os: "20.04"
           - track: "latest/edge"
             os: "22.04"
+          - track: "latest/edge"
+            os: "20.04"
+          - track: "latest/stable"
+            os: "20.04"
 
     steps:
       - name: Performance tuning

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,6 +110,10 @@ jobs:
         exclude:
           - test: cluster  # fan is not yet working on 24.04 kernel: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2064508
             os: "24.04"
+          - test: devlxd-vm  # not compatible with 4.0/*
+            track: "4.0/edge"
+          - test: devlxd-vm  # not compatible with 4.0/*
+            track: "4.0/stable"
           - test: efi-vars-editor-vm  # not compatible with 5.0/*
             track: "5.0/edge"
           - test: efi-vars-editor-vm  # not compatible with 5.0/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,43 +112,25 @@ jobs:
             os: "24.04"
           - test: devlxd-vm  # not compatible with 4.0/*
             track: "4.0/edge"
-          - test: devlxd-vm  # not compatible with 4.0/*
-            track: "4.0/stable"
           - test: efi-vars-editor-vm  # not compatible with 5.0/*
             track: "5.0/edge"
-          - test: efi-vars-editor-vm  # not compatible with 5.0/*
-            track: "5.0/stable"
           - test: efi-vars-editor-vm  # not compatible with 4.0/*
             track: "4.0/edge"
-          - test: efi-vars-editor-vm  # not compatible with 4.0/*
-            track: "4.0/stable"
           - test: storage-buckets  # not compatible with 4.0/*
             track: "4.0/edge"
-          - test: storage-buckets  # not compatible with 4.0/*
-            track: "4.0/stable"
           - test: "storage-vm ceph"  # waiting for integration with microceph
           - track: "4.0/edge"
             os: "24.04"
-          - track: "4.0/stable"
-            os: "24.04"
           - track: "5.0/edge"
-            os: "24.04"
-          - track: "5.0/stable"
             os: "24.04"
           - track: "5.0/edge"
             os: "20.04"
           - track: "5.21/edge"
             os: "20.04"
-          - track: "5.21/stable"
+          - track: "latest/edge"
             os: "20.04"
           - track: "latest/edge"
             os: "22.04"
-          - track: "latest/stable"
-            os: "22.04"
-          - track: "latest/edge"
-            os: "20.04"
-          - track: "latest/stable"
-            os: "20.04"
 
     steps:
       - name: Performance tuning

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,18 +160,6 @@ jobs:
           sudo ip link delete docker0
           sudo nft flush ruleset
 
-      - name: Remove needrestart
-        run: |
-          # XXX: workaround https://bugs.launchpad.net/ubuntu/+source/needrestart/+bug/2067800
-          #      needrestart restarting runner-provisioner.service causes an immediate job failure:
-          #
-          #Restarting services...
-          # /etc/needrestart/restart.d/systemd-manager
-          # systemctl restart packagekit.service php8.3-fpm.service runner-provisioner.service systemd-journald.service systemd-networkd.service systemd-resolved.service systemd-udevd.service udisks2.service walinuxagent.service
-          #Terminated
-          #++ cleanup
-          sudo apt-get autopurge -y needrestart
-
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,8 @@ jobs:
           - test: cluster  # fan is not yet working on 24.04 kernel: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2064508
             os: "24.04"
           # not compatible with 4.0/*
+          - test: cpu-vm
+            track: "4.0/edge"
           - test: devlxd-vm
             track: "4.0/edge"
           - test: efi-vars-editor-vm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,6 +114,14 @@ jobs:
             track: "5.0/edge"
           - test: efi-vars-editor-vm  # not compatible with 5.0/*
             track: "5.0/stable"
+          - test: efi-vars-editor-vm  # not compatible with 4.0/*
+            track: "4.0/edge"
+          - test: efi-vars-editor-vm  # not compatible with 4.0/*
+            track: "4.0/stable"
+          - test: storage-buckets  # not compatible with 4.0/*
+            track: "4.0/edge"
+          - test: storage-buckets  # not compatible with 4.0/*
+            track: "4.0/stable"
           - test: "storage-vm ceph"  # waiting for integration with microceph
           - track: "5.0/edge"
             os: "24.04"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,6 +117,8 @@ jobs:
             track: "4.0/edge"
           - test: efi-vars-editor-vm
             track: "4.0/edge"
+          - test: network-ovn
+            track: "4.0/edge"
           - test: storage-buckets
             track: "4.0/edge"
           - test: "storage-vm dir"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,6 +124,9 @@ jobs:
             track: "4.0/edge"
           - test: network-ovn
             track: "4.0/edge"
+          # https://github.com/canonical/pylxd/issues/590
+          - test: pylxd
+            track: "4.0/edge"
           - test: storage-buckets
             track: "4.0/edge"
           - test: storage-disks-vm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,8 +112,12 @@ jobs:
             os: "24.04"
           - test: efi-vars-editor-vm  # not compatible with 5.0/*
             track: "5.0/edge"
+          - test: efi-vars-editor-vm  # not compatible with 5.0/*
+            track: "5.0/stable"
           - test: "storage-vm ceph"  # waiting for integration with microceph
           - track: "5.0/edge"
+            os: "24.04"
+          - track: "5.0/stable"
             os: "24.04"
           - track: "latest/edge"
             os: "22.04"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,6 +121,8 @@ jobs:
             track: "4.0/edge"
           - test: storage-buckets
             track: "4.0/edge"
+          - test: storage-disks-vm
+            track: "4.0/edge"
           - test: "storage-vm dir"
             track: "4.0/edge"
           - test: "storage-vm btrfs"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,6 +143,8 @@ jobs:
             os: "20.04"
           - track: "latest/edge"
             os: "22.04"
+          - track: "latest/stable"
+            os: "22.04"
           - track: "latest/edge"
             os: "20.04"
           - track: "latest/stable"

--- a/bin/helpers
+++ b/bin/helpers
@@ -148,7 +148,6 @@ install_lxd() (
     else
         snap remove lxd || true
     fi
-
     snap install lxd --channel="${LXD_SNAP_CHANNEL}"
     snap list lxd
     uname -a
@@ -164,6 +163,12 @@ install_lxd() (
         systemctl stop snap.lxd.daemon
         cp "${LXD_SIDELOAD_PATH}" /var/snap/lxd/common/lxd.debug
         systemctl start snap.lxd.daemon
+    fi
+
+    # TODO remove once 4.0.10 is in 4.0/stable
+    if [ "$(lxc remote list -f csv | grep -cwF "minimal")" -lt 2 ]; then
+        lxc remote add ubuntu-minimal https://cloud-images.ubuntu.com/minimal/releases/ --protocol simplestreams || true
+        lxc remote add ubuntu-minimal-daily https://cloud-images.ubuntu.com/minimal/daily/ --protocol simplestreams || true
     fi
 )
 

--- a/bin/helpers
+++ b/bin/helpers
@@ -234,7 +234,7 @@ cleanup() {
         # Report some more information for diagnostic purposes
         snap list lxd
         uname -a
-        lxc list --all-projects
+        lxc list --all-projects || lxc list
 
         # LXD daemon logs
         echo "::group::lxd logs"

--- a/tests/cluster
+++ b/tests/cluster
@@ -60,7 +60,12 @@ for i in $(seq "${SIZE}"); do
         MEMBER_IP=$(lxc exec "${PREFIX}-$i" -- ip -4 addr show dev eth0 scope global | grep inet | cut -d' ' -f6 | cut -d/ -f1)
 
         # Get a join token
-        TOKEN="$(lxc exec "${PREFIX}-1" -- lxc cluster add --quiet "${PREFIX}-${i}")"
+        if echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/"; then
+            # 4.0 doesn't support --quiet
+            TOKEN="$(lxc exec "${PREFIX}-1" -- lxc cluster add "${PREFIX}-${i}" | tail -n1)"
+        else
+            TOKEN="$(lxc exec "${PREFIX}-1" -- lxc cluster add --quiet "${PREFIX}-${i}")"
+        fi
 
         lxc exec "${PREFIX}-$i" -- lxd init --preseed << EOF
 cluster:

--- a/tests/cluster
+++ b/tests/cluster
@@ -73,6 +73,12 @@ cluster:
   cluster_token: "${TOKEN}"
 EOF
     fi
+
+    # add minimal remotes if needed (TODO: remove once 4.0.10 is in 4.0/stable)
+    if [ "$(lxc exec "${PREFIX}-$i" -- lxc remote list -f csv | grep -cwF "minimal")" -lt 2 ]; then
+        lxc exec "${PREFIX}-$i" -- lxc remote add ubuntu-minimal https://cloud-images.ubuntu.com/minimal/releases/ --protocol simplestreams || true
+        lxc exec "${PREFIX}-$i" -- lxc remote add ubuntu-minimal-daily https://cloud-images.ubuntu.com/minimal/daily/ --protocol simplestreams || true
+    fi
 done
 
 echo "==> Validating the cluster"

--- a/tests/cluster
+++ b/tests/cluster
@@ -106,35 +106,51 @@ lxc exec "${PREFIX}-1" -- timeout 30s bash -c "grep -m1 ^SSH < /dev/tcp/${U2_IPV
 
 tmp_cert_dir="$(mktemp -d)"
 
-echo "==> Add restricted and unrestricted certificates"
-createCertificateAndKey "${tmp_cert_dir}/cert.key" "${tmp_cert_dir}/cert.crt" "cert.local"
-createCertificateAndKey "${tmp_cert_dir}/cert-restricted.key" "${tmp_cert_dir}/cert-restricted.crt" "cert-restricted.local"
-lxc config trust add "${tmp_cert_dir}/cert.crt"
-lxc config trust add "${tmp_cert_dir}/cert-restricted.crt" --restricted --projects default
-unrestricted_fingerprint="$(certificateFingerprintShort "${tmp_cert_dir}/cert.crt")"
-restricted_fingerprint="$(certificateFingerprintShort "${tmp_cert_dir}/cert-restricted.crt")"
+if hasNeededAPIExtension certificate_project; then
+    TEST_RESTRICTED=1
+else
+    echo "Skipping restricted certificate test, not supported"
+    TEST_RESTRICTED=0
+fi
 
-echo "==> Check the certificates for its permissions"
+echo "==> Add unrestricted certificate"
+createCertificateAndKey "${tmp_cert_dir}/cert.key" "${tmp_cert_dir}/cert.crt" "cert.local"
+lxc config trust add "${tmp_cert_dir}/cert.crt"
+unrestricted_fingerprint="$(certificateFingerprintShort "${tmp_cert_dir}/cert.crt")"
+
+if [ "${TEST_RESTRICTED}" = "1" ]; then
+  echo "==> Add restricted certificate"
+  createCertificateAndKey "${tmp_cert_dir}/cert-restricted.key" "${tmp_cert_dir}/cert-restricted.crt" "cert-restricted.local"
+  lxc config trust add "${tmp_cert_dir}/cert-restricted.crt" --restricted --projects default
+  restricted_fingerprint="$(certificateFingerprintShort "${tmp_cert_dir}/cert-restricted.crt")"
+fi
+
+echo "==> Check the certificates for their permissions"
 lxc query "/1.0/certificates/${unrestricted_fingerprint}" | jq -r ".restricted" | grep -xF false
 lxc query "/1.0/certificates/${unrestricted_fingerprint}" | jq -r ".type" | grep -xF client
-lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".restricted" | grep -xF true
-lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".type" | grep -xF client
-lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".projects[0]" | grep -xF default
 
-echo "==> Add restricted and unrestricted metrics certificates"
-createCertificateAndKey "${tmp_cert_dir}/metrics.key" "${tmp_cert_dir}/metrics.crt" "metrics.local"
-createCertificateAndKey "${tmp_cert_dir}/metrics-restricted.key" "${tmp_cert_dir}/metrics-restricted.crt" "metrics-restricted.local"
-lxc config trust add "${tmp_cert_dir}/metrics.crt" --type metrics
-lxc config trust add "${tmp_cert_dir}/metrics-restricted.crt" --type metrics --restricted --projects default
-unrestricted_metrics_fingerprint="$(certificateFingerprintShort "${tmp_cert_dir}/metrics.crt")"
-restricted_metrics_fingerprint="$(certificateFingerprintShort "${tmp_cert_dir}/metrics-restricted.crt")"
+if [ "${TEST_RESTRICTED}" = "1" ]; then
+  lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".restricted" | grep -xF true
+  lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".type" | grep -xF client
+  lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".projects[0]" | grep -xF default
+fi
 
-echo "==> Check the metrics certificates for its permissions"
-lxc query "/1.0/certificates/${unrestricted_metrics_fingerprint}" | jq -r ".restricted" | grep -xF false
-lxc query "/1.0/certificates/${unrestricted_metrics_fingerprint}" | jq -r ".type" | grep -xF metrics
-lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".restricted" | grep -xF true
-lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".type" | grep -xF metrics
-lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".projects[0]" | grep -xF default
+if [ "${TEST_RESTRICTED}" = "1" ]; then
+  echo "==> Add restricted and unrestricted metrics certificates"
+  createCertificateAndKey "${tmp_cert_dir}/metrics.key" "${tmp_cert_dir}/metrics.crt" "metrics.local"
+  createCertificateAndKey "${tmp_cert_dir}/metrics-restricted.key" "${tmp_cert_dir}/metrics-restricted.crt" "metrics-restricted.local"
+  lxc config trust add "${tmp_cert_dir}/metrics.crt" --type metrics
+  lxc config trust add "${tmp_cert_dir}/metrics-restricted.crt" --type metrics --restricted --projects default
+  unrestricted_metrics_fingerprint="$(certificateFingerprintShort "${tmp_cert_dir}/metrics.crt")"
+  restricted_metrics_fingerprint="$(certificateFingerprintShort "${tmp_cert_dir}/metrics-restricted.crt")"
+
+  echo "==> Check the metrics certificates for its permissions"
+  lxc query "/1.0/certificates/${unrestricted_metrics_fingerprint}" | jq -r ".restricted" | grep -xF false
+  lxc query "/1.0/certificates/${unrestricted_metrics_fingerprint}" | jq -r ".type" | grep -xF metrics
+  lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".restricted" | grep -xF true
+  lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".type" | grep -xF metrics
+  lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".projects[0]" | grep -xF default
+fi
 
 echo "==> Upgrading the cluster"
 for i in $(seq "${SIZE}"); do
@@ -161,16 +177,20 @@ lxc exec "${PREFIX}-1" -- lxc cluster list
 echo "==> Check the certificates for its permissions after cluster upgrade"
 lxc query "/1.0/certificates/${unrestricted_fingerprint}" | jq -r ".restricted" | grep -xF false
 lxc query "/1.0/certificates/${unrestricted_fingerprint}" | jq -r ".type" | grep -xF client
-lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".restricted" | grep -xF true
-lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".type" | grep -xF client
-lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".projects[0]" | grep -xF default
+if [ "${TEST_RESTRICTED}" = "1" ]; then
+    lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".restricted" | grep -xF true
+    lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".type" | grep -xF client
+    lxc query "/1.0/certificates/${restricted_fingerprint}" | jq -r ".projects[0]" | grep -xF default
+fi
 
-echo "==> Check the metrics certificates for its permissions after cluster upgrade"
-lxc query "/1.0/certificates/${unrestricted_metrics_fingerprint}" | jq -r ".restricted" | grep -xF false
-lxc query "/1.0/certificates/${unrestricted_metrics_fingerprint}" | jq -r ".type" | grep -xF metrics
-lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".restricted" | grep -xF true
-lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".type" | grep -xF metrics
-lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".projects[0]" | grep -xF default
+if [ "${TEST_RESTRICTED}" = "1" ]; then
+    echo "==> Check the metrics certificates for its permissions after cluster upgrade"
+    lxc query "/1.0/certificates/${unrestricted_metrics_fingerprint}" | jq -r ".restricted" | grep -xF false
+    lxc query "/1.0/certificates/${unrestricted_metrics_fingerprint}" | jq -r ".type" | grep -xF metrics
+    lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".restricted" | grep -xF true
+    lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".type" | grep -xF metrics
+    lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -r ".projects[0]" | grep -xF default
+fi
 
 echo "==> Deleting the cluster"
 for i in $(seq "${SIZE}"); do

--- a/tests/container
+++ b/tests/container
@@ -76,6 +76,11 @@ ignore_known_issues() {
 }
 
 for release in 20.04 22.04 24.04; do
+    if [ "${release}" = "24.04" ] && echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/"; then
+        echo "Skip 24.04 container tests on ${LXD_SNAP_CHANNEL}"
+        continue
+    fi
+
     IMAGE="ubuntu-minimal-daily:${release}"
 
     echo "==> unprivileged container (${release})"

--- a/tests/container
+++ b/tests/container
@@ -98,6 +98,12 @@ for release in 20.04 22.04 24.04; do
     isSystemdClean n1 || ignore_known_issues "nesting"
     lxc exec n1 -- snap install lxd --channel="${LXD_SNAP_CHANNEL}"
     lxc exec n1 -- lxd init --auto
+
+    # 4.0/* doesn't have ubuntu-minimal remotes
+    if [ "$(lxc exec n1 -- lxc remote list -f csv | grep -cwF "minimal")" -lt 2 ]; then
+        lxc exec n1 -- lxc remote add ubuntu-minimal https://cloud-images.ubuntu.com/minimal/releases/ --protocol simplestreams || true
+        lxc exec n1 -- lxc remote add ubuntu-minimal-daily https://cloud-images.ubuntu.com/minimal/daily/ --protocol simplestreams || true
+    fi
     lxc exec n1 -- lxc launch "${IMAGE}" n11
     sleep 5
     [ "$(lxc exec n1 -- lxc exec n11 -- systemctl --quiet --failed)" = "" ] || ignore_known_issues "nested"

--- a/tests/cpu-vm
+++ b/tests/cpu-vm
@@ -10,6 +10,11 @@ fi
 # Install LXD
 install_lxd
 
+if ! hasNeededAPIExtension cpu_hotplug; then
+  echo "Skipping test as CPU hotplugging not supported on ${LXD_SNAP_CHANNEL}"
+  exit 0
+fi
+
 # required for "CPU auto pinning" feature check
 # as we don't have a separate API extension for it
 # and we rely on the debug output in the LXD daemon logs.

--- a/tests/cpu-vm
+++ b/tests/cpu-vm
@@ -4,6 +4,7 @@ set -eux
 architecture="$(uname -m)"
 if [ "${architecture}" != "x86_64" ] && [ "${architecture}" != "s390x" ]; then
   echo "Skipping test as CPU hotplugging not supported on ${architecture}"
+  exit 0
 fi
 
 # Install LXD

--- a/tests/cpu-vm
+++ b/tests/cpu-vm
@@ -31,12 +31,18 @@ lxc storage create "${poolName}" "${poolDriver}"
 # still work
 lxc profile set default limits.kernel.nofile 50
 
-! lxc init v0 --vm --empty -c limits.kernel.cpu=46 -s "${poolName}" || false
+# 4.0 does not reject `limits.kernel.*` keys on VM instances
+if ! echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/"; then
+  ! lxc init v0 --vm --empty -c limits.kernel.cpu=46 -s "${poolName}" || false
+fi
 
 lxc init v0 --vm --empty -s "${poolName}"
 
-# limits.kernel.* only applies to containers (shouldn't work)
-! lxc config set v0 limits.kernel.as=1GiB || false
+# 4.0 does not reject `limits.kernel.*` keys on VM instances
+if ! echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/"; then
+  # limits.kernel.* only applies to containers (shouldn't work)
+  ! lxc config set v0 limits.kernel.as=1GiB || false
+fi
 
 lxc delete v0
 

--- a/tests/interception
+++ b/tests/interception
@@ -47,11 +47,11 @@ lxc exec c1 -- mknod /dev/mknod-test c 1 3
 lxc exec c1 -- mknod /root/mknod-test1 c 1 3
 
 ## bpf (needs 5.9 or higher)
-if runsMinimumKernel 5.9; then
+if runsMinimumKernel 5.9 && hasNeededAPIExtension container_syscall_intercept_bpf_devices; then
     lxc config set c1 security.syscalls.intercept.bpf=true security.syscalls.intercept.bpf.devices=true
     lxc restart c1 -f
 else
-    echo "Skipping security.syscalls.intercept.bpf config as the kernel is too old"
+    echo "Skipping security.syscalls.intercept.bpf config as the kernel is too old or LXD support missing"
 fi
 
 ## mount

--- a/tests/interception
+++ b/tests/interception
@@ -73,17 +73,13 @@ lxc exec c1 -- mount /dev/sda /mnt
 [ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "0:0" ]
 lxc exec c1 -- umount /mnt
 
-if hasNeededAPIExtension container_syscall_intercept_mount_fuse; then
-    lxc config unset c1 security.syscalls.intercept.mount.allowed
-    lxc config set c1 security.syscalls.intercept.mount.fuse=ext4=fuse2fs
-    lxc restart c1 -f
+lxc config unset c1 security.syscalls.intercept.mount.allowed
+lxc config set c1 security.syscalls.intercept.mount.fuse=ext4=fuse2fs
+lxc restart c1 -f
 
-    lxc exec c1 -- mount /dev/sda /mnt
-    [ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "0:0" ]
-    lxc exec c1 -- umount /mnt
-else
-    echo "Skipping mount fuse tests as the container_syscall_intercept_mount_fuse API extension is missing"
-fi
+lxc exec c1 -- mount /dev/sda /mnt
+[ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "0:0" ]
+lxc exec c1 -- umount /mnt
 
 if hasNeededAPIExtension container_syscall_intercept_finit_module; then
     # it can be any module which is present in the host filesystem and at the same time not used and can be unloaded

--- a/tests/interception
+++ b/tests/interception
@@ -68,10 +68,14 @@ lxc exec c1 -- mount /dev/sda /mnt
 [ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "65534:65534" ]
 lxc exec c1 -- umount /mnt
 
-lxc config set c1 security.syscalls.intercept.mount.shift=true
-lxc exec c1 -- mount /dev/sda /mnt
-[ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "0:0" ]
-lxc exec c1 -- umount /mnt
+if echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/"; then
+    echo "Skipping security.syscalls.intercept.mount.shift test, not compatible with ${LXD_SNAP_CHANNEL}"
+else
+    lxc config set c1 security.syscalls.intercept.mount.shift=true
+    lxc exec c1 -- mount /dev/sda /mnt
+    [ "$(lxc exec c1 -- stat --format=%u:%g /mnt)" = "0:0" ]
+    lxc exec c1 -- umount /mnt
+fi
 
 lxc config unset c1 security.syscalls.intercept.mount.allowed
 lxc config set c1 security.syscalls.intercept.mount.fuse=ext4=fuse2fs

--- a/tests/network-bridge-firewall
+++ b/tests/network-bridge-firewall
@@ -30,7 +30,7 @@ iptables --version 2>&1 | grep legacy
 ip6tables --version 2>&1 | grep legacy
 ebtables --version 2>&1 | grep legacy
 
-# Setup bridge filter and unmanaged bridge.s
+# Setup bridge filter and unmanaged bridges
 modprobe br_netfilter
 ip link add lxdbr0unmanaged type bridge
 

--- a/tests/network-bridge-firewall
+++ b/tests/network-bridge-firewall
@@ -13,7 +13,7 @@ IMAGE="${TEST_IMG:-ubuntu-daily:24.04}"
 set -x
 
 # Configure LXD
-lxc storage create default zfs
+lxc storage create default btrfs
 lxc network create lxdbr0 \
     ipv4.address=192.0.2.1/24 \
     ipv6.address=2001:db8::1/64 \

--- a/tests/network-routed
+++ b/tests/network-routed
@@ -32,7 +32,11 @@ lxc config device add v1 eth0 nic \
     ipv4.address=192.0.2.2,192.0.2.3 \
     ipv6.address=2001:db8::2,2001:db8::3
 
-lxc config set v1 cloud-init.network-config - << EOF
+NET_CONFIG_KEY="cloud-init.network-config"
+if ! hasNeededAPIExtension cloud_init; then
+    NET_CONFIG_KEY="user.network-config"
+fi
+lxc config set v1 "${NET_CONFIG_KEY}" - << EOF
 network:
   version: 2
   ethernets:

--- a/tests/vm-nesting
+++ b/tests/vm-nesting
@@ -94,7 +94,8 @@ start 5
 wait 5
 cmd 5 "snap wait system seed.loaded && snap install lxd --channel ${LXD_SNAP_CHANNEL}"
 cmd 5 "lxd init --auto"
-cmd 5 "lxc launch ${IMAGE} nested --vm -c limits.memory=512MiB -d root,size=3584MiB"
+cmd 5 "lxc profile device set default root size=3584MiB"
+cmd 5 "lxc launch ${IMAGE} nested --vm -c limits.memory=512MiB"
 delete 5
 
 echo "==> Test 5 containers each with one nested VM"
@@ -108,7 +109,8 @@ device_add 5 vsock unix-char source=/dev/vsock
 start 5
 cmd 5 "snap wait system seed.loaded && snap install lxd --channel ${LXD_SNAP_CHANNEL}"
 cmd 5 "lxd init --auto"
-cmd 5 "lxc launch ${IMAGE} nested --vm -c limits.memory=512MiB -d root,size=3584MiB"
+cmd 5 "lxc profile device set default root size=3584MiB"
+cmd 5 "lxc launch ${IMAGE} nested --vm -c limits.memory=512MiB"
 
 echo "==> Cleaning up"
 instCount="$(lxc list -f csv -c n t | wc -l)"

--- a/tests/vm-nesting
+++ b/tests/vm-nesting
@@ -6,12 +6,20 @@ set -eux
 # Install LXD.
 install_lxd
 
+VMs=10
+nestedVMs=5
 storageDriver="zfs"
-if echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/" && modinfo zfs | grep -qE '^version:\s*2\.2\.'; then
-    storageDriver="lvm"
-    # Allow more time to boot instances
-    export MAX_WAIT_SECONDS=180
-    echo "${LXD_SNAP_CHANNEL} does not support ZFS 2.2, falling back to ${storageDriver}"
+if echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/"; then
+    # VMs on 4.0 are more resource intensive and slower to boot
+    export MAX_WAIT_SECONDS=240
+
+    VMs=3
+    nestedVMs=2
+
+    if modinfo zfs | grep -qE '^version:\s*2\.2\.'; then
+        storageDriver="lvm"
+        echo "${LXD_SNAP_CHANNEL} does not support ZFS 2.2, falling back to ${storageDriver}"
+    fi
 fi
 
 # Configure LXD.
@@ -77,40 +85,40 @@ function delete() {
 	lxc delete -f "${instances[@]}"
 }
 
-echo "==> Test 10 VMs in parallel"
-init 10 --vm
-start 10
-delete 10
+echo "==> Test ${VMs} VMs in parallel"
+init "${VMs}" --vm
+start "${VMs}"
+delete "${VMs}"
 
-echo "==> Test 10 VMs in parallel for vsock ID collision"
-init 10 --vm
-conf 10 volatile.vsock_id=42
-start 10
-delete 10
+echo "==> Test ${VMs} VMs in parallel for vsock ID collision"
+init "${VMs}" --vm
+conf "${VMs}" volatile.vsock_id=42
+start "${VMs}"
+delete "${VMs}"
 
-echo "==> Test 5 VMs each with one nested VM"
-init 5 --vm
-start 5
-wait 5
-cmd 5 "snap wait system seed.loaded && snap install lxd --channel ${LXD_SNAP_CHANNEL}"
-cmd 5 "lxd init --auto"
-cmd 5 "lxc profile device set default root size=3584MiB"
-cmd 5 "lxc launch ${IMAGE} nested --vm -c limits.memory=512MiB"
-delete 5
+echo "==> Test ${nestedVMs} VMs each with one nested VM"
+init "${nestedVMs}" --vm
+start "${nestedVMs}"
+wait "${nestedVMs}"
+cmd "${nestedVMs}" "snap wait system seed.loaded && snap install lxd --channel ${LXD_SNAP_CHANNEL}"
+cmd "${nestedVMs}" "lxd init --auto"
+cmd "${nestedVMs}" "lxc profile device set default root size=3584MiB"
+cmd "${nestedVMs}" "lxc launch ${IMAGE} nested --vm -c limits.memory=512MiB"
+delete "${nestedVMs}"
 
-echo "==> Test 5 containers each with one nested VM"
-init 5
-conf 5 security.devlxd.images=true
-conf 5 security.nesting=true
-device_add 5 kvm unix-char source=/dev/kvm
-device_add 5 vhost-net unix-char source=/dev/vhost-net
-device_add 5 vhost-vsock unix-char source=/dev/vhost-vsock
-device_add 5 vsock unix-char source=/dev/vsock
-start 5
-cmd 5 "snap wait system seed.loaded && snap install lxd --channel ${LXD_SNAP_CHANNEL}"
-cmd 5 "lxd init --auto"
-cmd 5 "lxc profile device set default root size=3584MiB"
-cmd 5 "lxc launch ${IMAGE} nested --vm -c limits.memory=512MiB"
+echo "==> Test ${VMs} containers each with one nested VM"
+init "${VMs}"
+conf "${VMs}" security.devlxd.images=true
+conf "${VMs}" security.nesting=true
+device_add "${VMs}" kvm unix-char source=/dev/kvm
+device_add "${VMs}" vhost-net unix-char source=/dev/vhost-net
+device_add "${VMs}" vhost-vsock unix-char source=/dev/vhost-vsock
+device_add "${VMs}" vsock unix-char source=/dev/vsock
+start "${VMs}"
+cmd "${VMs}" "snap wait system seed.loaded && snap install lxd --channel ${LXD_SNAP_CHANNEL}"
+cmd "${VMs}" "lxd init --auto"
+cmd "${VMs}" "lxc profile device set default root size=3584MiB"
+cmd "${VMs}" "lxc launch ${IMAGE} nested --vm -c limits.memory=512MiB"
 
 echo "==> Cleaning up"
 instCount="$(lxc list -f csv -c n t | wc -l)"

--- a/tests/vm-nesting
+++ b/tests/vm-nesting
@@ -6,12 +6,16 @@ set -eux
 # Install LXD.
 install_lxd
 
+VM_IN_CTN=1
 VMs=10
 nestedVMs=5
 storageDriver="zfs"
 if echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/"; then
     # VMs on 4.0 are more resource intensive and slower to boot
     export MAX_WAIT_SECONDS=240
+
+    # VMs inside containers do not work
+    VM_IN_CTN=0
 
     VMs=3
     nestedVMs=2
@@ -106,19 +110,23 @@ cmd "${nestedVMs}" "lxc profile device set default root size=3584MiB"
 cmd "${nestedVMs}" "lxc launch ${IMAGE} nested --vm -c limits.memory=512MiB"
 delete "${nestedVMs}"
 
-echo "==> Test ${VMs} containers each with one nested VM"
-init "${VMs}"
-conf "${VMs}" security.devlxd.images=true
-conf "${VMs}" security.nesting=true
-device_add "${VMs}" kvm unix-char source=/dev/kvm
-device_add "${VMs}" vhost-net unix-char source=/dev/vhost-net
-device_add "${VMs}" vhost-vsock unix-char source=/dev/vhost-vsock
-device_add "${VMs}" vsock unix-char source=/dev/vsock
-start "${VMs}"
-cmd "${VMs}" "snap wait system seed.loaded && snap install lxd --channel ${LXD_SNAP_CHANNEL}"
-cmd "${VMs}" "lxd init --auto"
-cmd "${VMs}" "lxc profile device set default root size=3584MiB"
-cmd "${VMs}" "lxc launch ${IMAGE} nested --vm -c limits.memory=512MiB"
+if [ "${VM_IN_CTN}" = "1" ]; then
+    echo "==> Test ${nestedVMs} containers each with one nested VM"
+    init "${nestedVMs}"
+    conf "${nestedVMs}" security.devlxd.images=true
+    conf "${nestedVMs}" security.nesting=true
+    device_add "${nestedVMs}" kvm unix-char source=/dev/kvm
+    device_add "${nestedVMs}" vhost-net unix-char source=/dev/vhost-net
+    device_add "${nestedVMs}" vhost-vsock unix-char source=/dev/vhost-vsock
+    device_add "${nestedVMs}" vsock unix-char source=/dev/vsock
+    start "${nestedVMs}"
+    cmd "${nestedVMs}" "snap wait system seed.loaded && snap install lxd --channel ${LXD_SNAP_CHANNEL}"
+    cmd "${nestedVMs}" "lxd init --auto"
+    cmd "${nestedVMs}" "lxc profile device set default root size=3584MiB"
+    cmd "${nestedVMs}" "lxc launch ${IMAGE} nested --vm -c limits.memory=510MiB"
+else
+    echo "Skipping VM in container tests on ${LXD_SNAP_CHANNEL}"
+fi
 
 echo "==> Cleaning up"
 instCount="$(lxc list -f csv -c n t | wc -l)"

--- a/tests/vm-nesting
+++ b/tests/vm-nesting
@@ -6,9 +6,17 @@ set -eux
 # Install LXD.
 install_lxd
 
+storageDriver="zfs"
+if echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/" && modinfo zfs | grep -qE '^version:\s*2\.2\.'; then
+    storageDriver="lvm"
+    # Allow more time to boot instances
+    export MAX_WAIT_SECONDS=180
+    echo "${LXD_SNAP_CHANNEL} does not support ZFS 2.2, falling back to ${storageDriver}"
+fi
+
 # Configure LXD.
 lxc project switch default
-lxc storage create default zfs size=30GiB
+lxc storage create default "${storageDriver}" size=30GiB
 lxc network create lxdbr0
 
 IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"


### PR DESCRIPTION
This adds 15 tests to the existing test matrix. This put the current total at 105 jobs taking ~15 hours of CI runtime.