### PR TITLE
test/storage-disks-vm: Wait for agent to mount path inside guest

### DIFF
--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -111,10 +111,17 @@ lxc stop -f v1
 
 # Check adding a disk to a vm with a long name (max 63) and slash to test possible problems with long socket paths or long qemu device tags
 LONG_DEVICE_NAME="device-with-very-long-name-and-/-4-qemu-property-handling-test_"
+DEVICE_HOTPLUG="1"
+
 # XXX: LXD releases 5.21 and earlier don't support long names (yet)
 if echo "${LXD_SNAP_CHANNEL}" | grep -E '^([45]\.0|5\.21)/'; then
     echo "::warning::${LXD_SNAP_CHANNEL} detected, using a shorter name"
     LONG_DEVICE_NAME="notSoLongName"
+fi
+
+# XXX: LXD releases 5.0 and earlier don't hotplugging
+if echo "${LXD_SNAP_CHANNEL}" | grep -E '^[45]\.0/'; then
+  DEVICE_HOTPLUG="0"
 fi
 
 lxc init "${IMAGE}" v2 --vm
@@ -122,23 +129,29 @@ lxc config device add v2 "${LONG_DEVICE_NAME}" disk source="${testRoot}/allowed1
 lxc start v2
 waitInstanceReady v2
 lxc exec v2 -- mountpoint /mnt/bar1
-if [ "${LONG_DEVICE_NAME}" = "notSoLongName" ]; then
-    lxc stop -f v2
-    lxc config device remove v2 "${LONG_DEVICE_NAME}"
-    lxc start v2
-    waitInstanceReady v2
-    ! lxc exec v2 -- mountpoint /mnt/bar2 || false  # Make sure nothing is mounted
-    lxc config device add v2 "${LONG_DEVICE_NAME}" disk source="${testRoot}/allowed1" path="/mnt/bar2" # Test hotplugging as well
-    lxc exec v2 -- mountpoint /mnt/bar2
-else
-    lxc config device remove v2 "${LONG_DEVICE_NAME}"
-    sleep 1
-    ! lxc exec v2 -- mountpoint /mnt/bar1 || false # Just tests for mountpoint disconnected, not unmount.
-    lxc config device add v2 "${LONG_DEVICE_NAME}" disk source="${testRoot}/allowed1" path="/mnt/bar2" # Test hotplugging as well
-    lxc exec v2 -- mountpoint /mnt/bar2
-    lxc config device remove v2 "${LONG_DEVICE_NAME}"
-    sleep 1
-    ! lxc exec v2 -- mountpoint /mnt/bar2 || false # Just tests for mountpoint disconnected, not unmount.
+
+if [ "${DEVICE_HOTPLUG}" = "1" ]; then
+  if [ "${LONG_DEVICE_NAME}" = "notSoLongName" ]; then
+      # Only test hotplug, not hotunplug on 5.0 and earlier.
+      lxc stop -f v2
+      lxc config device remove v2 "${LONG_DEVICE_NAME}"
+      lxc start v2
+      waitInstanceReady v2
+      ! lxc exec v2 -- mountpoint /mnt/bar2 || false  # Make sure nothing is mounted
+      lxc config device add v2 "${LONG_DEVICE_NAME}" disk source="${testRoot}/allowed1" path="/mnt/bar2" # Test hotplugging as well
+      sleep 1
+      lxc exec v2 -- mountpoint /mnt/bar2
+  else
+      lxc config device remove v2 "${LONG_DEVICE_NAME}"
+      sleep 1
+      ! lxc exec v2 -- mountpoint /mnt/bar1 || false # Just tests for mountpoint disconnected, not unmount.
+      lxc config device add v2 "${LONG_DEVICE_NAME}" disk source="${testRoot}/allowed1" path="/mnt/bar2" # Test hotplugging as well
+      sleep 1
+      lxc exec v2 -- mountpoint /mnt/bar2
+      lxc config device remove v2 "${LONG_DEVICE_NAME}"
+      sleep 1
+      ! lxc exec v2 -- mountpoint /mnt/bar2 || false # Just tests for mountpoint disconnected, not unmount.
+  fi
 fi
 lxc delete -f v2
 


### PR DESCRIPTION
Also depends on https://github.com/canonical/lxd/pull/13674 in order to resolve an internal race between qemu/guest OS and lxd-agent.