### PR TITLE
Update long device name on TPM tests

### DIFF
--- a/tests/tpm-vm
+++ b/tests/tpm-vm
@@ -45,7 +45,7 @@ lxc stop "${vmName}" --force
 
 # TPM names are included on the swtpm socket path and long socket paths can cause problems if not handled correctly.
 echo "==> Test handling TPMs with long names"
-longName="tpm-device-with-long-name-for-testing"
+longName="device-with-very-long-name-and-/-4-qemu-property-handling-test_"
 # XXX: LXD releases 5.21 and earlier don't support long names (yet)
 if echo "${LXD_SNAP_CHANNEL}" | grep -E '^([45]\.0|5\.21)/'; then
     echo "::warning::${LXD_SNAP_CHANNEL} detected, using a shorter name"


### PR DESCRIPTION
This even longer name tests for problems with device ID trmming on QEMU and tests using `/` in TPM names. See [#13671](https://github.com/canonical/lxd/pull/13671).