### PR TITLE
Tests: Add support for the PowerFlex SDC operation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To run the VM storage tests on the Dell PowerFlex driver, provide the following 
 * `POWERFLEX_GATEWAY_VERIFY`: Whether to verify the HTTP gateway's certificate. The default is `true`.
 * `POWERFLEX_USER`: Name of the PowerFlex user
 * `POWERFLEX_PASSWORD`: Password of the PowerFlex user
+* `POWERFLEX_MODE`: Operation mode for the consumption of storage volumes. The default is `nvme`.
 
 # Infrastructure managed by IS
 

--- a/bin/helpers
+++ b/bin/helpers
@@ -199,7 +199,8 @@ createPowerFlexPool() (
     powerflex.gateway="${POWERFLEX_GATEWAY}" \
     powerflex.gateway.verify="${POWERFLEX_GATEWAY_VERIFY:-true}" \
     powerflex.user.name="${POWERFLEX_USER}" \
-    powerflex.user.password="${POWERFLEX_PASSWORD}"
+    powerflex.user.password="${POWERFLEX_PASSWORD}" \
+    powerflex.mode="${POWERFLEX_MODE:-nvme}"
 )
 
 # createCertificateAndKey: creates a new key pair.


### PR DESCRIPTION
This adds a new variable `POWERFLEX_MODE` that allows running the PowerFlex storage tests either in `nvme` or `sdc` mode.