### PR TITLE
bin/test-image: Disable secureboot for specific images

### DIFF
--- a/bin/test-image
+++ b/bin/test-image
@@ -75,9 +75,11 @@ if [ "${TYPE}" = "vm" ]; then
         -c limits.memory=4GiB
 
     # Some distros don't support secure boot.
-    if [ "$(lxc image get-property "${TEST_IMAGE}" requirements.secureboot 2>/dev/null)" = "false" ]; then
-        lxc config set "${TEST_IMAGE}" security.secureboot=false
-    fi
+    case "${DISTRO}" in
+        alpine|archlinux|gentoo|nixos|openeuler)
+            lxc config set "${TEST_IMAGE}" security.secureboot=false
+            ;;
+    esac
 
     INSTANCES="${TEST_IMAGE}"
 


### PR DESCRIPTION
Revert https://github.com/canonical/lxd-ci/pull/205

We cannot extract `requirements` from manually built images, as LXD retrieves them from the image server - they are not part of the image metadata.

This should fix issues with VM tests on Alpine, Arch, ...

Example passing build for Alpine: https://github.com/MusicDin/lxd-ci/actions/runs/9712230286