### PR TITLE
Add `/dev/disk/by-id` link tests

### DIFF
--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -110,8 +110,26 @@ lxc exec v1 -- ls -l /mnt/foo1
 lxc stop -f v1
 
 # Check adding a disk to a vm with a long name (max 63) and slash to test possible problems with long socket paths or long qemu device tags
-LONG_DEVICE_NAME="device-with-very-long-name-and-/-4-qemu-property-handling-test_"
+LONG_DEVICE_NAME="device-/-with-very-long-name-and-4-qemu-property-handling-test_"
 DEVICE_HOTPLUG="1"
+
+lxc launch "${IMAGE}" v2 --vm
+
+echo "==> Check /dev/disk/by-id with escaped long device name"
+# Create block device source inside allowed directory
+touch "${testRoot}/allowed1/lxd-block-test"
+truncate -s 5m "${testRoot}/allowed1/lxd-block-test"
+
+waitInstanceReady v2
+lxc config device add v2 ${LONG_DEVICE_NAME} disk source="${testRoot}/allowed1/lxd-block-test"
+sleep 3
+BLOCK_SPECIAL_FILE="$(lxc exec v2 -- readlink -f /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_device-----with-)"
+lxc exec v2 -- test -b "$BLOCK_SPECIAL_FILE"
+lxc config device remove v2 ${LONG_DEVICE_NAME}
+sleep 3
+! lxc exec v2 -- stat "$BLOCK_SPECIAL_FILE" || false
+! lxc exec v2 -- stat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_device-----with- || false
+lxc stop -f v2
 
 # XXX: LXD releases 5.21 and earlier don't support long names (yet)
 if echo "${LXD_SNAP_CHANNEL}" | grep -E '^([45]\.0|5\.21)/'; then
@@ -124,7 +142,6 @@ if echo "${LXD_SNAP_CHANNEL}" | grep -E '^[45]\.0/'; then
   DEVICE_HOTPLUG="0"
 fi
 
-lxc init "${IMAGE}" v2 --vm
 lxc config device add v2 "${LONG_DEVICE_NAME}" disk source="${testRoot}/allowed1" path="/mnt/bar1"
 lxc start v2
 waitInstanceReady v2
@@ -230,6 +247,7 @@ lxc network delete lxdbr0
 
 rm "${testRoot}/allowed1/not-allowed1"
 rm "${testRoot}/allowed1/not-allowed2"
+rm "${testRoot}/allowed1/lxd-block-test"
 rmdir "${testRoot}/allowed1/foo1"
 rmdir "${testRoot}/allowed1/foo2"
 rm "${testRoot}/allowed1/foolink"

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -63,10 +63,10 @@ for poolDriver in $poolDriverList; do
         lxc info v1
 
         echo "==> Check /dev/disk/by-id"
-        lxc exec v1 -- test -e /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root
-        lxc exec v1 -- test -e /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root-part1
+        lxc exec v1 -- test -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root
+        lxc exec v1 -- test -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root-part1
         if lxc exec v1 -- mount | grep -qwF /boot/efi; then
-            lxc exec v1 -- test -e /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root-part15
+                lxc exec v1 -- test -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root-part15
         fi
 
         echo "==> Check config drive is readonly"
@@ -343,9 +343,9 @@ for poolDriver in $poolDriverList; do
         lxc exec v1 -- rm /srv/rw/lxd-test-rw
         lxc exec v1 -- rm /srv/rw/lxd-test
 
-        # Check block disks are available.
-        lxc exec v1 -- stat -c "%F" /dev/sdb | grep -xF "block special file"
-        lxc exec v1 -- stat -c "%F" /dev/sdc | grep -xF "block special file"
+        # Check /dev/disk/by-id/ links
+        lxc exec v1 -- test -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_block1ro
+        lxc exec v1 -- test -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_block1rw
 
         # Check the rw driver accepts writes and the ro does not.
         ! lxc exec v1 -- dd if=/dev/urandom of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_block1ro bs=512 count=2 || false
@@ -378,10 +378,13 @@ for poolDriver in $poolDriverList; do
         fi
         lxc storage volume attach "${poolName}" vol1 v1
         sleep 3
-        lxc exec v1 -- stat -c "%F" /dev/sdb | grep -xF "block special file"
+
+        BLOCK_SPECIAL_FILE="$(lxc exec v1 -- readlink -f /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_vol1)"
+        lxc exec v1 -- test -b "$BLOCK_SPECIAL_FILE"
         lxc storage volume detach "${poolName}" vol1 v1
         sleep 3
-        ! lxc exec v1 -- stat -c "%F" /dev/sdb || false
+        ! lxc exec v1 -- stat "$BLOCK_SPECIAL_FILE" || false
+        ! lxc exec v1 -- stat /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_vol1 || false
         lxc storage volume delete "${poolName}" vol1
 
         lxc config device add v1 block1 disk source="/tmp/lxd-test-${poolName}/lxd-test-block" readonly=true
@@ -399,10 +402,13 @@ for poolDriver in $poolDriverList; do
         # Hot plug cloud-init:config ISO.
         lxc config device add v1 cloudinit disk source=cloud-init:config
         sleep 3
+        BLOCK_SPECIAL_FILE="$(readlink -f /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_cloudinit)"
+        lxc exec v1 -- test -b "${BLOCK_SPECIAL_FILE}"
         lxc exec v1 -- mount -t iso9660 -o ro /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_cloudinit /mnt
         lxc exec v1 -- umount /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_cloudinit
         lxc config device remove v1 cloudinit
-        ! lxc exec v1 -- stat /dev/sr0 || false
+        ! lxc exec v1 -- stat "${BLOCK_SPECIAL_FILE}" || false
+        ! lxc exec v1 -- stat /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_cloudinit || false
 
         # Remove temporary directory.
         echo "==> Stopping VM"

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -82,10 +82,10 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking VM root disk size is 3584MiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / MiB))" -eq "3584" ]
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / MiB))" -eq "3584" ]
         else
                 echo "==> Checking VM root disk size is 8GiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "8" ]
         fi
 
         echo "foo" | lxc exec v1 -- tee /root/foo.txt
@@ -126,10 +126,10 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking VM snapshot copy root disk size is 3584MiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / MiB))" -eq "3584" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / MiB))" -eq "3584" ]
         else
                 echo "==> Checking VM snapshot copy root disk size is 8GiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "8" ]
         fi
         lxc delete -f v2
 
@@ -160,10 +160,10 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking VM snapshot copy root disk size is 3584MiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / MiB))" -eq "3584" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / MiB))" -eq "3584" ]
         else
                 echo "==> Checking VM snapshot copy root disk size is 8GiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "8" ]
         fi
         lxc delete -f v2
 
@@ -198,10 +198,10 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking VM snapshot copy root disk size is 3584MiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / MiB))" -eq "3584" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / MiB))" -eq "3584" ]
         else
                 echo "==> Checking VM snapshot copy root disk size is 8GiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "8" ]
         fi
         lxc delete -f v2
 
@@ -271,13 +271,13 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking VM root disk size is 4GiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "4" ]
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "4" ]
 
                 echo "==> Check VM shrink is blocked"
                 ! lxc config device set v1 root size=3584MiB || false
         else
                 echo "==> Checking VM root disk size is 16GiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "16" ]
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "16" ]
 
                 echo "==> Check VM shrink is blocked"
                 ! lxc config device set v1 root size=8GiB || false
@@ -348,8 +348,8 @@ for poolDriver in $poolDriverList; do
         lxc exec v1 -- stat -c "%F" /dev/sdc | grep -xF "block special file"
 
         # Check the rw driver accepts writes and the ro does not.
-        ! lxc exec v1 -- dd if=/dev/urandom of=/dev/sdb bs=512 count=2 || false
-        lxc exec v1 -- dd if=/dev/urandom of=/dev/sdc bs=512 count=2
+        ! lxc exec v1 -- dd if=/dev/urandom of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_block1ro bs=512 count=2 || false
+        lxc exec v1 -- dd if=/dev/urandom of=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_block1rw bs=512 count=2
 
         # Remove temporary directory (should now be empty aside from block file).
         echo "==> Stopping VM"
@@ -399,8 +399,8 @@ for poolDriver in $poolDriverList; do
         # Hot plug cloud-init:config ISO.
         lxc config device add v1 cloudinit disk source=cloud-init:config
         sleep 3
-        lxc exec v1 -- mount -t iso9660 -o ro /dev/sr0 /mnt
-        lxc exec v1 -- umount /dev/sr0
+        lxc exec v1 -- mount -t iso9660 -o ro /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_cloudinit /mnt
+        lxc exec v1 -- umount /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_cloudinit
         lxc config device remove v1 cloudinit
         ! lxc exec v1 -- stat /dev/sr0 || false
 
@@ -427,10 +427,10 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking VM root disk size is 4GiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "4" ]
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "4" ]
         else
                 echo "==> Checking VM root disk size is 16GiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "16" ]
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "16" ]
         fi
 
         echo "==> Deleting VM and reset pool volume.size"
@@ -473,10 +473,10 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking VM root disk size is 3584MiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / MiB))" -eq "3584" ]
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / MiB))" -eq "3584" ]
         else
                 echo "==> Checking VM root disk size is 8GiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "8" ]
         fi
         lxc stop -f v1
 
@@ -500,10 +500,10 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking copied VM root disk size is 3584MiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / MiB))" -eq "3584" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / MiB))" -eq "3584" ]
         else
                 echo "==> Checking copied VM root disk size is 8GiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "8" ]
         fi
         lxc delete -f v2
         lxc storage delete "${poolName}-2"
@@ -522,10 +522,10 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking copied VM root disk size is 3584MiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / MiB))" -eq "3584" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / MiB))" -eq "3584" ]
         else
                 echo "==> Checking copied VM root disk size is 8GiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "8" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "8" ]
         fi
         lxc delete -f v2
 
@@ -543,10 +543,10 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking copied VM root disk size is 5GiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "5" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "5" ]
         else
                 echo "==> Checking copied VM root disk size is 16GiB"
-                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "16" ]
+                [ "$(($(lxc exec v2 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "16" ]
         fi
         lxc delete -f v2
         lxc storage delete "${poolName}-${dstPoolDriver}"
@@ -576,10 +576,10 @@ for poolDriver in $poolDriverList; do
 
         if [ "${poolDriver}" != "powerflex" ]; then
                 echo "==> Checking new VM root disk size has default volume size of 10GiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "10" ]
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "10" ]
         else
                 echo "==> Checking new VM root disk size has default volume size of 16GiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/sda) / GiB))" -eq "16" ]
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "16" ]
         fi
 
         echo "===> Renaming VM"

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -61,7 +61,7 @@ do
 	echo "==> Start VM and add content to custom block volume"
 	lxc start v1
 	waitInstanceReady v1
-
+	lxc exec v1 -- test -b /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_vol1
 	lxc exec v1 -- /bin/sh -c "mkfs.ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_vol1 && mount /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_vol1 /mnt && echo foo > /mnt/bar && umount /mnt"
 
 	echo "==> Stop VM and detach custom volumes"
@@ -107,6 +107,16 @@ do
 	  lxc storage volume attach "${poolName}" vol6 v1
 	  lxc storage volume attach "${poolName}" vol5 v2
 	  lxc storage volume attach "${poolName}" vol6 v2
+
+	  echo "===> Check if /dev/disk/by-id representations are accurate"
+	  lxc start v1 v2
+	  waitInstanceReady v1
+	  waitInstanceReady v2
+	  lxc exec v1 -- test -b /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_vol5
+	  lxc exec v1 -- test -b /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_vol6
+	  lxc exec v2 -- test -b /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_vol5
+	  lxc exec v2 -- test -b /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_vol6
+	  lxc stop -f v1 v2
     else
 	  echo "==> Skipping custom ISO volume tests, not supported"
     fi

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -62,7 +62,7 @@ do
 	lxc start v1
 	waitInstanceReady v1
 
-	lxc exec v1 -- /bin/sh -c "mkfs.ext4 /dev/sdb && mount /dev/sdb /mnt && echo foo > /mnt/bar && umount /mnt"
+	lxc exec v1 -- /bin/sh -c "mkfs.ext4 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_vol1 && mount /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_vol1 /mnt && echo foo > /mnt/bar && umount /mnt"
 
 	echo "==> Stop VM and detach custom volumes"
 	lxc stop -f v1
@@ -118,22 +118,22 @@ do
 	waitInstanceReady v2
 
 	# shellcheck disable=2016
-	lxc exec v1 -- /bin/sh -c 'mount /dev/sdb /mnt && [ $(cat /mnt/bar) = foo ] && umount /mnt'
+	lxc exec v1 -- /bin/sh -c 'mount /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_vol2 /mnt && [ $(cat /mnt/bar) = foo ] && umount /mnt'
 	# shellcheck disable=2016
-	lxc exec v1 -- /bin/sh -c 'mount /dev/sdc /mnt && [ $(cat /mnt/bar) = foo ] && umount /mnt'
+	lxc exec v1 -- /bin/sh -c 'mount /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_vol3 /mnt && [ $(cat /mnt/bar) = foo ] && umount /mnt'
 
     if hasNeededAPIExtension custom_volume_iso; then
 	  # mount ISOs and check content
 	  # shellcheck disable=2016
-	  lxc exec v1 -- /bin/sh -c 'mount /dev/sr0 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo && umount /mnt'
+	  lxc exec v1 -- /bin/sh -c 'mount /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_vol5 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo && umount /mnt'
 	  # shellcheck disable=2016
-	  lxc exec v1 -- /bin/sh -c 'mount /dev/sr1 /mnt && [ $(cat /mnt/bar) = bar ] && ! touch /mnt/bar && umount /mnt'
+	  lxc exec v1 -- /bin/sh -c 'mount /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_vol6 /mnt && [ $(cat /mnt/bar) = bar ] && ! touch /mnt/bar && umount /mnt'
 
 	  # concurrent readonly ISO mounts
 	  # shellcheck disable=2016
-	  lxc exec v1 -- /bin/sh -c 'mount /dev/sr0 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo'
+	  lxc exec v1 -- /bin/sh -c 'mount /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_vol5 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo'
 	  # shellcheck disable=2016
-	  lxc exec v2 -- /bin/sh -c 'mount /dev/sr0 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo'
+	  lxc exec v2 -- /bin/sh -c 'mount /dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_lxd_vol5 /mnt && [ $(cat /mnt/foo) = foo ] && ! touch /mnt/foo'
 	  lxc exec v1 -- umount /mnt
 	  lxc exec v2 -- umount /mnt
     else


### PR DESCRIPTION
This adds tests for checking if `/dev/disk/by-id` links are being properly set up for different kinds of block devices. Also moves non pool specific tests away from `storage-vm`.
This is needed for [#13672](https://github.com/canonical/lxd/pull/13672) and [#13671](https://github.com/canonical/lxd/pull/13671).