### PR TITLE
image-setup: Ensure bzip2 package is installed

### DIFF
--- a/.github/actions/image-setup/action.yml
+++ b/.github/actions/image-setup/action.yml
@@ -17,6 +17,7 @@ runs:
       run: |
         sudo apt-get -qq update
         sudo apt-get install -y --no-install-recommends \
+            bzip2 \
             debootstrap \
             git \
             gpg \


### PR DESCRIPTION
Ensure package `bzip2` is installed. It is installed by default on amd64 runners, but is missing on arm64 runners which causes an issue when decompressing busybox image.

```
Error: Error while downloading source: Failed to unpack "busybox-1.36.1.tar.bz2": Unpack failed: Failed to run: tar --restrict --force-local -C /home/runner/build/cache/src --numeric-owner --xattrs-include=* -jxf -: exit status 2 (tar (grandchild): bzip2: Cannot exec: No such file or directory
```