### PR TITLE
openeuler: Add 24.03 LTS release and use US mirror

### DIFF
--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -25,6 +25,7 @@ jobs:
           - 20.03
           - 22.03
           - 23.03
+          - 24.03
         variant:
           - default
           - cloud

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -59,10 +59,18 @@ jobs:
           [ "${ARCH}" = "amd64" ] && IMAGE_ARCH="x86_64"
           [ "${ARCH}" = "arm64" ] && IMAGE_ARCH="aarch64"
 
+          EXTRA_ARGS=""
+
+          # Temporary disable source overwrite for 22.03, as it is missing on the mirror.
+          if [ ${{ matrix.release }} != "22.03" ]; then
+              EXTRA_ARGS="-o source.url=https://mirrors.ocf.berkeley.edu/openeuler/"
+          fi
+
           ./bin/build-distro "${YAML}" "${ARCH}" "${TYPE}" "${TIMEOUT}" "${{ env.target }}" \
               -o image.architecture="${IMAGE_ARCH}" \
               -o image.release=${{ matrix.release }} \
-              -o image.variant=${{ matrix.variant }}
+              -o image.variant=${{ matrix.variant }} \
+              ${EXTRA_ARGS}
 
       - name: Print build artifacts
         run: ls -lah "${{ env.target }}"


### PR DESCRIPTION
Adds 24.03 LTS release and uses US mirror. The mirror is disabled for `22.03` because files are currently missing on the mirror.

Here is the passing build (all except 22.03 which is still being downloaded while other releases are already built and tested): https://github.com/MusicDin/lxd-ci/actions/runs/9746516110/job/26897050776