### PR TITLE
image-setup: Ensure package build-essential is installed

### DIFF
--- a/.github/actions/image-setup/action.yml
+++ b/.github/actions/image-setup/action.yml
@@ -17,6 +17,7 @@ runs:
       run: |
         sudo apt-get -qq update
         sudo apt-get install -y --no-install-recommends \
+            build-essential \
             bzip2 \
             debootstrap \
             git \


### PR DESCRIPTION
Follow up on: #220

Adding package `build-essential` to the list of required packages.

Current error is [`gcc: not found`](https://github.com/canonical/lxd-ci/actions/runs/9746540143/job/26897139278#step:4:129) on arm64 runner.

