### PR TITLE
github: Drop OpenEuler 20.03 LTS and 23.03 images (EOL 2024-03)

### DIFF
--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 20.03
           - 22.03
           - 23.03
           - 24.03

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         release:
           - 22.03
-          - 23.03
           - 24.03
         variant:
           - default


### PR DESCRIPTION
https://www.openeuler.org/en/other/lifecycle/ says:
> LTS version: released every two years and provides community support for four years. openEuler 20.03 LTS, the first LTS version, was released in March 2020.

This means it went EOL in March 2024 which is also confirmed by the graph on the same page.

Also, 23.03 is not a LTS release so:
> Innovation version: released every six months and provides community support for six months.

So it went EOL at the end of 2023.