### PR TITLE
NixOS 23.11 (EOL: 2024-06-30)

### DIFF
--- a/.github/workflows/image-nixos.yml
+++ b/.github/workflows/image-nixos.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         release:
           - unstable
-          - 23.11
           - 24.05
         variant:
           - default

--- a/bin/test-image
+++ b/bin/test-image
@@ -102,11 +102,6 @@ EOF
     fi
 else
     for PRIV in "priv" "unpriv"; do
-        if [ "${PRIV}" = "priv" ] && [ "${DISTRO}" = "nixos" ] && [ "${RELEASE}" = "23.11" ]; then
-            # NixOS 23.11 will never support privileged containers, but future versions do.
-            continue
-        fi
-
         lxc init "${TEST_IMAGE}" "${TEST_IMAGE}-${PRIV}"
         INSTANCES="${INSTANCES} ${TEST_IMAGE}-${PRIV}"
 


### PR DESCRIPTION
https://discourse.nixos.org/t/nixos-24-05-released/46279:
> The 23.11 “Tapir” release is now officially deprecated, and will reach its end-of-life and stop receiving security updates after 2024-06-30.