### PR TITLE
github: Drop Devuan 3/Beowulf images (EOL)

### DIFF
--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - beowulf
           - chimaera
           - daedalus
         variant:


### PR DESCRIPTION
Devuan 3/Beowulf is based on Debian 10/Buster which went EOL on 2024-06-30 (#223)