### PR TITLE
bin/test-image: do a post cloud-init reboot test for cloud variants

### DIFF
--- a/bin/test-image
+++ b/bin/test-image
@@ -268,6 +268,28 @@ for url in $(lxc query "/1.0/instances" | jq -r .[] | grep "${TEST_IMAGE}"); do
     fi
 done
 
+# Check that cloud variants can be rebooted cleanly.
+if [ "${VARIANT}" = "cloud" ]; then
+    for name in ${INSTANCES}; do
+        echo "==> Performing post cloud-init reboot test"
+        lxc exec "${name}" -- cloud-init status --wait --long
+
+        # If systemd is available, use it to wait for any other job to complete before the restart
+        lxc exec "${name}" -- systemctl is-system-running --wait || true
+
+        lxc restart "${name}"
+        waitInstanceReady "${name}"
+
+        # cloud-init status.
+        if lxc exec "${name}" -- cloud-init status --wait --long; then
+            echo "===> PASS: cloud-init reboot: ${name}"
+        else
+            echo "===> FAIL: cloud-init reboot: ${name}"
+            FAIL=1
+        fi
+    done
+fi
+
 # Check that all instances can be stopped.
 echo "==> Performing shutdown test"
 STOPPED=0


### PR DESCRIPTION
```
root@cloud:~/lxd-ci# ./bin/test-image container debian bookworm cloud ~/build/
==> Fetching the image
Image imported with fingerprint: 102e1df1d4f872c0952870649de4f22233770bb4b4fe810fbf43993ccc34c4c4
==> Creating the instances
Creating container-debian-cloud-priv
Creating container-debian-cloud-unpriv    
==> Starting the instances                
==> Waiting for instances to start
+-------------------------------+---------+----------------------+-----------------------------------------------+-----------+-----------+
|             NAME              |  STATE  |         IPV4         |                     IPV6                      |   TYPE    | SNAPSHOTS |
+-------------------------------+---------+----------------------+-----------------------------------------------+-----------+-----------+
| container-debian-cloud-priv   | RUNNING | 10.98.120.65 (eth0)  | fd42:7fd0:ebeb:4e35:216:3eff:fe14:d3bd (eth0) | CONTAINER | 0         |
+-------------------------------+---------+----------------------+-----------------------------------------------+-----------+-----------+
| container-debian-cloud-unpriv | RUNNING | 10.98.120.207 (eth0) | fd42:7fd0:ebeb:4e35:216:3eff:fece:efb8 (eth0) | CONTAINER | 0         |
+-------------------------------+---------+----------------------+-----------------------------------------------+-----------+-----------+
==> Performing network tests
===> PASS: systemd clean: container-debian-cloud-priv
===> PASS: IPv4 address: container-debian-cloud-priv
===> PASS: IPv6 address: container-debian-cloud-priv
===> PASS: DNS resolution: container-debian-cloud-priv
===> PASS: cloud-init user-data provisioning: container-debian-cloud-priv
===> PASS: cloud-init vendor-data provisioning: container-debian-cloud-priv
===> PASS: systemd clean: container-debian-cloud-unpriv
===> PASS: IPv4 address: container-debian-cloud-unpriv
===> PASS: IPv6 address: container-debian-cloud-unpriv
===> PASS: DNS resolution: container-debian-cloud-unpriv
===> PASS: cloud-init user-data provisioning: container-debian-cloud-unpriv
===> PASS: cloud-init vendor-data provisioning: container-debian-cloud-unpriv
==> Performing post cloud-init reboot test

status: done
boot_status_code: enabled-by-generator
last_update: Wed, 03 Jul 2024 23:16:50 +0000
detail:
DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
running
...
status: done
boot_status_code: enabled-by-generator
last_update: Wed, 03 Jul 2024 23:17:08 +0000
detail:
DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
===> PASS: cloud-init reboot: container-debian-cloud-priv

status: done
boot_status_code: enabled-by-generator
last_update: Wed, 03 Jul 2024 23:16:51 +0000
detail:
DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
running
.....
status: done
boot_status_code: enabled-by-generator
last_update: Wed, 03 Jul 2024 23:17:13 +0000
detail:
DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
===> PASS: cloud-init reboot: container-debian-cloud-unpriv
==> Performing shutdown test
+-------------------------------+---------+------+------+-----------+-----------+
|             NAME              |  STATE  | IPV4 | IPV6 |   TYPE    | SNAPSHOTS |
+-------------------------------+---------+------+------+-----------+-----------+
| container-debian-cloud-priv   | STOPPED |      |      | CONTAINER | 0         |
+-------------------------------+---------+------+------+-----------+-----------+
| container-debian-cloud-unpriv | STOPPED |      |      | CONTAINER | 0         |
+-------------------------------+---------+------+------+-----------+-----------+
root@cloud:~/lxd-ci# echo $?
0
```