### PR TITLE
images: Run scheduled image builds only on `canonical/lxd-ci` repo

### DIFF
--- a/.github/workflows/image-almalinux.yml
+++ b/.github/workflows/image-almalinux.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   almalinux:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   alpine:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   alt:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-amazonlinux.yml
+++ b/.github/workflows/image-amazonlinux.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   amazonlinux:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-20.04' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-archlinux.yml
+++ b/.github/workflows/image-archlinux.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   archlinux:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-busybox.yml
+++ b/.github/workflows/image-busybox.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   busybox:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   centos:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   debian:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   devuan:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   fedora:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-funtoo.yml
+++ b/.github/workflows/image-funtoo.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   funtoo:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   gentoo:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-kali.yml
+++ b/.github/workflows/image-kali.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   kali:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   mint:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/image-nixos.yml
+++ b/.github/workflows/image-nixos.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   nixos:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   openeuler:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   opensuse:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   openwrt:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   oracle:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-20.04' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-rockylinux.yml
+++ b/.github/workflows/image-rockylinux.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   rockylinux:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   slackware:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   ubuntu:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/image-voidlinux.yml
+++ b/.github/workflows/image-voidlinux.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   voidlinux:
+    if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Prevents running scheduled image builds on repository forks.

There are some alternative solutions, but IMO limiting scheduled image builds to `canonical/lxd-ci` repository is most suitable:
- Disable actions on fork (This prevents running a workflow manually on fork)
- Disable specific workflows (This prevents running a workflow manually on fork)
- Remove main branch on the fork or apply those changes on the main branch (This needs to be done on each fork - works for me, but thought this change would be nice for all forks)