### PR TITLE
images: Fix cloud-init check after reboot

### DIFF
--- a/bin/test-image
+++ b/bin/test-image
@@ -282,6 +282,9 @@ if [ "${VARIANT}" = "cloud" ]; then
         lxc restart "${name}"
         waitInstanceReady "${name}"
 
+        # Give instance extra few seconds to boot properly.
+        sleep 10
+
         # cloud-init status.
         if lxc exec "${name}" -- cloud-init status --wait --long; then
             echo "===> PASS: cloud-init reboot: ${name}"

--- a/bin/test-image
+++ b/bin/test-image
@@ -275,7 +275,9 @@ if [ "${VARIANT}" = "cloud" ]; then
         lxc exec "${name}" -- cloud-init status --wait --long
 
         # If systemd is available, use it to wait for any other job to complete before the restart
-        lxc exec "${name}" -- systemctl is-system-running --wait || true
+        if lxc exec "${name}" -- test -d /run/systemd/system/; then
+            lxc exec "${name}" -- systemctl is-system-running --wait || true
+        fi
 
         lxc restart "${name}"
         waitInstanceReady "${name}"


### PR DESCRIPTION
I've tried reproducing the issue with cloud-init check failing after reboot locally, but without success. However, I'm able to reproduce the issue consistently on GH runners.

I'm suspecting that cloud-init is invoked before instance is fully ready.

Adding a 10 second delay after instance is *fully* ready fixes the issue. It is not the most convenient one, but is the similar approach we use when we initially create instances.

https://github.com/canonical/lxd-ci/blob/b54cb611530c537c00035684326337af53568688/bin/test-image#L167-L168

Here are some builds on fork using this *fix*:
- AlmaLinux: https://github.com/MusicDin/lxd-ci/actions/runs/9843294370
- Oracle linux: https://github.com/MusicDin/lxd-ci/actions/runs/9843273759
- Alpine linux (3 attempts - all successful): https://github.com/MusicDin/lxd-ci/actions/runs/9843202312

@simondeziel Any thoughts?