### PR TITLE
github: force ed25519 host key algo in image-upload

### DIFF
--- a/.github/actions/image-upload/action.yml
+++ b/.github/actions/image-upload/action.yml
@@ -52,7 +52,7 @@ runs:
         # First upload contents to the temporary dir and once fully uploaded
         # move the directory to the final destination to avoid potential race
         # where simplestream-maintainer includes partially uploaded images.
-        sftp -P ${SSH_PORT} -b - "${SSH_USER}@${SSH_HOST}" <<EOF
+        sftp -oHostKeyAlgorithms=ssh-ed25519 -P ${SSH_PORT} -b - "${SSH_USER}@${SSH_HOST}" <<EOF
             put -R ${SRC_DIR}-upload/*
             rename "${IMG_DIR}/.${VERSION}" "${IMG_DIR}/${VERSION}"
             bye


### PR DESCRIPTION
We had a few workflows fail when trying to upload their images to the backing server:

```
$ sftp ...
Host key verification failed.
Connection closed.
```

The unexpected host key was also seen on job retries but only for a few runners. While this looked very suspicious, I think the explation is fairly simple.

When we setup the images server, we removed all host keys but the Ed25519 one. This is then the key whose fingerprint is hardcoded in the runners building the images (in their `~/.ssh/known_hosts`).

However, on July 2nd 2024, I (`10.131.10.107` is my VPN IP) pulled the updates on the images server due to a security fix landing for openssh:

```
ubuntu@prod-lxd-images:~$ last -ai | head -n 3
ubuntu   pts/0        Wed Jul 10 20:59   still logged in    10.131.10.107
ubuntu   pts/0        Thu Jul  4 16:42 - 17:06  (00:23)     10.131.10.107
ubuntu   pts/0        Tue Jul  2 00:28 - 00:40  (00:11)     10.131.10.107
```

```
root@images:~# head -n5 /var/log/apt/history.log

Start-Date: 2024-07-02  00:40:08
Commandline: apt-get dist-upgrade -V
Upgrade: openssh-client:amd64 (1:8.9p1-3ubuntu0.7, 1:8.9p1-3ubuntu0.10), openssh-server:amd64 (1:8.9p1-3ubuntu0.7, 1:8.9p1-3ubuntu0.10), openssh-sftp-server:amd64 (1:8.9p1-3ubuntu0.7, 1:8.9p1-3ubuntu0.10)
End-Date: 2024-07-02  00:40:16
```

This in turn explains why we have **new** (non-Ed25519) host keys:

```
root@images:~# ll /etc/ssh/ssh_host_*
-rw-r--r-- 1 root root  601 Mar 18 20:58 /etc/ssh/ssh_host_dsa_key.pub
-rw------- 1 root root  505 Jul  2 00:40 /etc/ssh/ssh_host_ecdsa_key
-rw-r--r-- 1 root root  173 Jul  2 00:40 /etc/ssh/ssh_host_ecdsa_key.pub
-rw------- 1 root root  399 Mar 18 20:58 /etc/ssh/ssh_host_ed25519_key
-rw-r--r-- 1 root root   93 Mar 18 20:58 /etc/ssh/ssh_host_ed25519_key.pub
-rw------- 1 root root 2590 Jul  2 00:40 /etc/ssh/ssh_host_rsa_key
-rw-r--r-- 1 root root  565 Jul  2 00:40 /etc/ssh/ssh_host_rsa_key.pub
```

Now the question was: why are only some GH runners affected.

When looking at the failing ones (AmazonLinux and Oracle), they both are using Ubuntu 20.04 runners rather than the usual Ubuntu 22.04. Presumably, on 20.04, the preferred host key algorithm was not Ed25519. As such, force this algorithm in the sftp session.