### PR TITLE
tests/snapd: Add quick check for snap preseed handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,6 +97,7 @@ jobs:
           - network-bridge-firewall
           - network-ovn
           - network-routed
+          - snapd
           - storage-buckets
           - storage-disks-vm
           - "storage-vm dir"

--- a/bin/helpers
+++ b/bin/helpers
@@ -139,7 +139,10 @@ install_deps() (
 )
 
 # install_lxd: install LXD from a specific channel or `latest/edge` if none is provided.
+# Optional argument: boolean which indicates whether to start the daemon. Default is true.
 install_lxd() (
+    local start_daemon="${1:-true}"
+
     # Wait for snapd seeding
     waitSnapdSeed
 
@@ -151,11 +154,13 @@ install_lxd() (
         snap remove lxd || true
     fi
 
-    snap install lxd --channel="${LXD_SNAP_CHANNEL}"
+    snap install lxd --channel="${LXD_SNAP_CHANNEL}" --cohort=+
     snap list lxd
     uname -a
     cat /proc/cmdline
-    lxd waitready --timeout=300
+    if [ "$start_daemon" = "true" ]; then
+        lxd waitready --timeout=300
+    fi
 
     # Silence the "If this is your first time running LXD on this machine" banner
     # on first invocation
@@ -165,7 +170,9 @@ install_lxd() (
     if [ -n "${LXD_SIDELOAD_PATH:-}" ]; then
         systemctl stop snap.lxd.daemon
         cp "${LXD_SIDELOAD_PATH}" /var/snap/lxd/common/lxd.debug
-        systemctl start snap.lxd.daemon
+        if [ "$start_daemon" = "true" ]; then
+            systemctl start snap.lxd.daemon
+        fi
     fi
 )
 

--- a/tests/snapd
+++ b/tests/snapd
@@ -82,8 +82,6 @@ lxc profile device add default root disk pool=default path=/
 lxc network create lxdbr0
 lxc profile device add default eth0 nic nictype=bridged parent=lxdbr0 name=eth0
 
-snap set lxd ceph.builtin=true
-
 systemctl restart snap.lxd.daemon.service
 
 for _ in $(seq 60); do
@@ -94,50 +92,5 @@ done
 useradd -m ${TEST_USER} -G lxd
 LXC=$(command -v lxc)
 su ${TEST_USER} -c "${LXC} info"
-
-# Container creation test
-lxc launch images:alpine/edge unprivileged
-lxc launch images:alpine/edge privileged -c security.privileged=true
-lxc launch images:alpine/edge isolated -c security.idmap.isolated=true
-
-# Storage backends test
-if modprobe -q -n btrfs; then
-    lxc storage create test-btrfs btrfs
-    lxc launch images:alpine/edge -s test-btrfs btrfs
-fi
-
-if modprobe -q -n zfs && ! grep -q ^0.7 < /sys/module/zfs/version; then
-    lxc storage create test-zfs zfs
-    lxc launch images:alpine/edge -s test-zfs zfs
-fi
-
-if [ "${ID}" != "ubuntu-core" ] && [ "${ID}" != "elementary" ] && modprobe -q -n dm_mod; then
-    lxc storage create test-lvm lvm volume.size=25MB
-    lxc launch images:alpine/edge -s test-lvm lvm
-fi
-
-if [ "${ID}" != "ubuntu-core" ] && [ "${VERSION_CODENAME:-""}" != "xenial" ] && [ "${ID}" != "centos" ] && modprobe -q -n rbd; then
-    curl http://canonical-lxd.stgraber.org/config/ceph-snap.sh | sh -eu
-
-    lxc storage create test-ceph ceph "ceph.osd.pool_name=$(mktemp -u snaptest-XXX)" volume.size=25MB ceph.osd.pg_num=1
-    lxc launch images:alpine/edge -s test-ceph ceph
-fi
-
-if [ "${track}" != "3.0" ]; then
-    lxc query /1.0/resources
-fi
-
-lxc file push /usr/bin/snap unprivileged/tmp/
-echo foo | lxc file push - unprivileged/tmp/foo
-[ "$(lxc file pull unprivileged/tmp/foo -)" = "foo" ]
-
-# Basic validation of running containers
-for container in $(lxc list --fast | tail -n+3 | grep "^| " | cut -d' ' -f2); do
-    lxc exec "${container}" -- ls /
-    lxc info "${container}"
-done
-
-sleep 10
-lxc list
 
 RET=0

--- a/tests/snapd
+++ b/tests/snapd
@@ -3,26 +3,10 @@ set -eux
 
 TEST_USER="testuser"
 
-# Configure to use the proxy
-curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
+# Install lxd without starting daemon
+install_lxd false
 
-if [ "${track}" = "latest" ]; then
-    snapd_channel=${channel}
-else
-    snapd_channel=${track}/${channel}
-fi
-
-echo "==> Installing LXD snap from ${track}/${channel}"
-snap remove lxd || true
-snap version
-snap list
-snap install lxd --channel="${snapd_channel}" --cohort=+
-
-for _ in $(seq 60); do
-    lxd waitready --timeout=10 >/dev/null 2>&1 && break
-done
-
-lxc --version
+lxd waitready --timeout=300
 
 # LXD setup
 lxc storage create default dir
@@ -30,12 +14,6 @@ lxc profile device add default root disk pool=default path=/
 
 lxc network create lxdbr0
 lxc profile device add default eth0 nic nictype=bridged parent=lxdbr0 name=eth0
-
-systemctl restart snap.lxd.daemon.service
-
-for _ in $(seq 60); do
-    lxd waitready --timeout=10 >/dev/null 2>&1 && break
-done
 
 # Check that user access works
 useradd -m ${TEST_USER} -G lxd

--- a/tests/snapd
+++ b/tests/snapd
@@ -1,29 +1,24 @@
 #!/bin/sh
 set -eux
 
-# Source host information
-# shellcheck disable=SC1091
-[ -e "/etc/os-release" ] && . /etc/os-release
-
-track=${1:-latest}
-channel=${2:-stable}
-
 export PATH="${PATH}:/var/lib/snapd/snap/bin:/snap/bin"
 
 RET=1
+TEST_USER="testuser"
+
 cleanup() {
     REBOOT=0
 
     set +e
     echo "==> Cleaning up"
-    for container in $(lxc list --fast | tail -n+3 | grep "^| " | cut -d' ' -f2); do
+        for container in $(lxc list --fast | tail -n+3 | grep "^| " | cut -d' ' -f2); do
         lxc delete "${container}" -f || true
     done
 
     for image in $(lxc image list | tail -n+3 | grep "^| " | cut -d'|' -f3 | sed "s/^ //g"); do
         lxc image delete "${image}" || true
     done
-
+    
     for profile in $(lxc profile list | tail -n+3 | grep "^| " | cut -d' ' -f2); do
         printf 'config: {}\ndevices: {}' | lxc profile edit "${profile}" || true
     done
@@ -96,14 +91,9 @@ for _ in $(seq 60); do
 done
 
 # Check that user access works
-if [ "${ID}" != "ubuntu-core" ]; then
-    (
-        set -e
-        usermod -G lxd -a jenkins || true
-        LXC=$(which lxc)
-        su jenkins -c "${LXC} info"
-    )
-fi
+useradd -m ${TEST_USER} -G lxd
+LXC=$(command -v lxc)
+su ${TEST_USER} -c "${LXC} info"
 
 # Container creation test
 lxc launch images:alpine/edge unprivileged

--- a/tests/snapd
+++ b/tests/snapd
@@ -6,7 +6,13 @@ TEST_USER="testuser"
 # Install lxd without starting daemon
 install_lxd false
 
+# Set preseed via snap
+snap set lxd daemon.preseed='{"config": {"core.https_address": "[::]:8443"}}'
+
 lxd waitready --timeout=300
+
+# Check that preseed via snap works
+lxc config show | grep -qF "core.https_address: '[::]:8443'" 
 
 # LXD setup
 lxc storage create default dir

--- a/tests/snapd
+++ b/tests/snapd
@@ -1,58 +1,7 @@
 #!/bin/sh
 set -eux
 
-export PATH="${PATH}:/var/lib/snapd/snap/bin:/snap/bin"
-
-RET=1
 TEST_USER="testuser"
-
-cleanup() {
-    REBOOT=0
-
-    set +e
-    echo "==> Cleaning up"
-        for container in $(lxc list --fast | tail -n+3 | grep "^| " | cut -d' ' -f2); do
-        lxc delete "${container}" -f || true
-    done
-
-    for image in $(lxc image list | tail -n+3 | grep "^| " | cut -d'|' -f3 | sed "s/^ //g"); do
-        lxc image delete "${image}" || true
-    done
-    
-    for profile in $(lxc profile list | tail -n+3 | grep "^| " | cut -d' ' -f2); do
-        printf 'config: {}\ndevices: {}' | lxc profile edit "${profile}" || true
-    done
-
-    for network in $(lxc network list | grep YES | grep "^| " | cut -d' ' -f2); do
-        lxc network delete "${network}" || true
-    done
-
-    for storage in $(lxc storage list | tail -n+3 | grep "^| " | cut -d' ' -f2); do
-        lxc storage delete "${storage}" || REBOOT=1
-    done
-
-    echo "==> Removing LXD"
-    umount -l /var/snap/lxd/common/shmounts
-    snap remove lxd
-    pkill -x -9 lxd
-    pkill -x -9 dnsmasq
-
-    if [ "${RET}" = "0" ]; then
-        echo ""
-        echo "==> Test passed"
-        exit 0
-    fi
-
-    echo ""
-    echo "==> Test failed"
-
-    if [ "${REBOOT}" = "1" ]; then
-        reboot
-    fi
-
-    exit "${RET}"
-}
-trap cleanup EXIT HUP INT TERM
 
 # Configure to use the proxy
 curl -s http://canonical-lxd.stgraber.org/config/snapd.sh | sh
@@ -93,4 +42,19 @@ useradd -m ${TEST_USER} -G lxd
 LXC=$(command -v lxc)
 su ${TEST_USER} -c "${LXC} info"
 
-RET=0
+# Cleanup
+echo "==> Deleting test user"
+userdel -r ${TEST_USER} 2>/dev/null || true
+
+echo "==> Deleting network device"
+lxc profile device remove default eth0
+
+echo "==> Deleting network"
+lxc network delete lxdbr0
+
+echo "==> Deleting storage"
+lxc profile device remove default root
+lxc storage delete default
+
+# shellcheck disable=SC2034
+FAIL=0


### PR DESCRIPTION
This PR adds a quick check to ensure that preseeds set via snap are handled, and makes updates to `tests/snapd` to remove redundant testing. 

`tests/snapd` now runs in the pipeline.