### PR TITLE
images: Remove openEuler mirror exception for release 22.03

### DIFF
--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -59,18 +59,11 @@ jobs:
           [ "${ARCH}" = "amd64" ] && IMAGE_ARCH="x86_64"
           [ "${ARCH}" = "arm64" ] && IMAGE_ARCH="aarch64"
 
-          EXTRA_ARGS=""
-
-          # Temporary disable source overwrite for 22.03, as it is missing on the mirror.
-          if [ ${{ matrix.release }} != "22.03" ]; then
-              EXTRA_ARGS="-o source.url=https://mirrors.ocf.berkeley.edu/openeuler/"
-          fi
-
           ./bin/build-distro "${YAML}" "${ARCH}" "${TYPE}" "${TIMEOUT}" "${{ env.target }}" \
               -o image.architecture="${IMAGE_ARCH}" \
               -o image.release=${{ matrix.release }} \
               -o image.variant=${{ matrix.variant }} \
-              ${EXTRA_ARGS}
+              -o source.url=https://mirrors.ocf.berkeley.edu/openeuler/
 
       - name: Print build artifacts
         run: ls -lah "${{ env.target }}"


### PR DESCRIPTION
The mirror has been updated to include 22.03 release. Therefore, exception in action step is no longer required.

Passing build (on fork): https://github.com/MusicDin/lxd-ci/actions/runs/10140831559