### PR TITLE
Fix intermittent failure on snapd seed

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -1,12 +1,14 @@
 # shellcheck disable=SC2148
 
 # waitSnapdSeed: wait for snapd to be seeded.
+# Optional argument: timeout in seconds, defaults to 60.
 waitSnapdSeed() (
+  waitSecs="${1:-60}"
   set +x
-  if timeout 60 snap wait system seed.loaded; then
+  if timeout "${waitSecs}" snap wait system seed.loaded; then
     return 0 # Success.
   fi
-  echo "snapd not seeded after 60s"
+  echo "snapd not seeded after ${waitSecs}s"
   return 1 # Failed.
 )
 

--- a/tests/devlxd-container
+++ b/tests/devlxd-container
@@ -85,6 +85,7 @@ if hasNeededAPIExtension instance_ready_state; then
   [ "$(lxc config get c1 volatile.last_state.ready)" = "false" ]
 
   lxc start c1
+  waitInstanceBooted c1
 else
   echo "Skipping instance Ready state tests, not supported"
 fi
@@ -99,7 +100,7 @@ fi
 
 # We need snapd to be ready before the next tests. Finagle the waitSnapdSeed function definition into the container and run it.
 # shellcheck disable=SC3044 # Ignore "declare is undefined" shellcheck error.
-lxc exec c1 -- sh -c "$(declare -f waitSnapdSeed); waitSnapdSeed"
+lxc exec c1 -- snap wait system seed.loaded
 lxc exec c1 -- snap remove --purge lxd || true
 lxc exec c1 -- snap install lxd --channel="${LXD_SNAP_CHANNEL}"
 lxc exec c1 -- /snap/bin/lxd init --auto


### PR DESCRIPTION
The `devlxd-container` tests are timing out when waiting for snapd to be seeded inside the container that will run a nested LXD.

This PR calls `waitInstanceBooted` after the container starts, then waits indefinitely for snap to be seeded. This approach is that same as in the `cluster` test.