### PR TITLE
Test devlxd image export for virtual machines

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -168,8 +168,15 @@ install_lxd() (
     touch ~/snap/lxd/common/config/config.yml
 
     if [ -n "${LXD_SIDELOAD_PATH:-}" ]; then
-        systemctl stop snap.lxd.daemon
         cp "${LXD_SIDELOAD_PATH}" /var/snap/lxd/common/lxd.debug
+        if [ "$start_daemon" = "true" ]; then
+            systemctl start snap.lxd.daemon
+        fi
+    fi
+
+    if [ -n "${LXD_AGENT_SIDELOAD_PATH:-}" ]; then
+        mount --bind "${LXD_AGENT_SIDELOAD_PATH}" /snap/lxd/current/bin/lxd-agent
+        systemctl restart snap.lxd.daemon
         if [ "$start_daemon" = "true" ]; then
             systemctl start snap.lxd.daemon
         fi

--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -11,7 +11,7 @@ install_lxd
 lxc network create lxdbr0
 lxc profile device add default eth0 nic network=lxdbr0
 
-IMAGE="${TEST_IMG:-ubuntu-daily:24.04}"
+IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"
 
 poolName="vmpool$$"
 poolDriver=dir
@@ -20,7 +20,12 @@ echo "==> Create storage pool using driver ${poolDriver}"
 lxc storage create "${poolName}" "${poolDriver}"
 
 echo "==> Create VM and boot"
-lxc launch "${IMAGE}" v1 --vm -s "${poolName}"
+if hasNeededAPIExtension devlxd_images_vm; then
+  lxc launch "${IMAGE}" v1 --vm -s "${poolName}" -c security.devlxd.images=true
+else
+  lxc launch "${IMAGE}" v1 --vm -s "${poolName}"
+fi
+
 waitInstanceReady v1
 lxc info v1
 
@@ -94,9 +99,34 @@ waitInstanceBooted v1
 lxc exec v1 -- snap remove --purge lxd || true
 lxc exec v1 -- snap install lxd --channel="${LXD_SNAP_CHANNEL}"
 lxc exec v1 -- /snap/bin/lxd init --auto
+if [ -n "${LXD_SIDELOAD_PATH:-}" ]; then
+    lxc file push "${LXD_SIDELOAD_PATH}" v1/var/snap/lxd/common/lxd.debug
+    lxc exec v1 -- systemctl restart snap.lxd.daemon
+fi
+if [ -n "${LXD_AGENT_SIDELOAD_PATH:-}" ]; then
+  lxc file push "${LXD_AGENT_SIDELOAD_PATH}" "v1/root/$(basename "${LXD_AGENT_SIDELOAD_PATH}")"
+  lxc exec v1 -- mount --bind "$(basename "${LXD_AGENT_SIDELOAD_PATH}")" /snap/lxd/current/bin/lxd-agent
+  lxc exec v1 -- systemctl restart snap.lxd.daemon
+fi
+
+monitorPID=""
+if hasNeededAPIExtension devlxd_images_vm; then
+  lxc monitor --type lifecycle --format json > monitor.json 2>&1 &
+  monitorPID="${!}"
+fi
+
 lxc exec v1 -- /snap/bin/lxc launch "${TEST_IMG:-ubuntu-minimal-daily:24.04}" v1v1 --vm
 sleep 30
 lxc exec v1 -- /snap/bin/lxc info v1v1 | grep -F RUNNING
+
+if hasNeededAPIExtension devlxd_images_vm; then
+  kill -9 "${monitorPID}"
+
+  # If the guest retrieved the image from the host, the host should emit an "image-retrieved" lifecycle event. The
+  # requestor address tells us that this was definitely the guest.
+  [ "$(grep -wF 'image-retrieved' monitor.json | jq -r '.metadata.requestor.address')" = "@devlxd" ]
+  rm monitor.json
+fi
 
 echo "==> Deleting VM"
 lxc delete -f v1


### PR DESCRIPTION
Amends `devlxd-vm` to test for image export over devlxd. To test this locally, I added functionality to the tests to allow sideloading the lxd-agent.