### PR TITLE
Use `/` in the gpu device name

### DIFF
--- a/tests/gpu-vm
+++ b/tests/gpu-vm
@@ -30,7 +30,7 @@ lxc info --resources
 for i in $(seq 1 4); do
 	lxc init "${IMAGE}" "v${i}" --vm -c security.secureboot=false
 	if [ "${1}" = "nvidia" ]; then
-		lxc config device add "v${i}" vgpu gpu gputype=mdev pci=0000:07:00.0 mdev=nvidia-468
+		lxc config device add "v${i}" vgpu/0 gpu gputype=mdev pci=0000:07:00.0 mdev=nvidia-468
 	fi
 	lxc start "v${i}"
 done


### PR DESCRIPTION
I made a mistake and this PR does not make sense with an `mdev` GPU, just a physical one.
This can be disregarded.