### PR TITLE
Sleep after hotplugging block dev

### DIFF
--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -116,6 +116,7 @@ echo "==> Checking disk device hotplug support"
 lxc config device remove v1 block1rw
 lxc config device remove v1 block1ro
 lxc config device add v1 block1 disk source="${testRoot}/allowed1/lxd-block-test" readonly=true
+sleep 1
 # shellcheck disable=SC2016
 DISK_DEV="$(basename "$(lxc exec v1 -- readlink -f /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_block1)")"
 lxc exec v1 -- sh -c "for i in \$(seq 10); do test -e /sys/block/${DISK_DEV}/ro && break; echo \"Waiting for sys file to appear (\${i}s)\"; sleep 1; done"


### PR DESCRIPTION
This test has shown to be flaky because the device is not effectively added before the next command executes (See https://github.com/canonical/lxd-ci/actions/runs/10297255515/job/28500067002#step:8:637).
So a short sleep makes this test more consistent, as it is already done in other places in the tests where hotplugging devices is performed.