### PR TITLE
OpenWrt 22.03 is EOL

### DIFF
--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         release:
           - snapshot
-          - 22.03
           - 23.05
         variant:
           - default

--- a/images/openwrt.yaml
+++ b/images/openwrt.yaml
@@ -357,5 +357,4 @@ actions:
     rm -f /etc/rc.d/*sysntpd
   releases:
   - snapshot
-  - 22.03
   - 23.05


### PR DESCRIPTION
Release 22.03 went EOL in July 2024, https://openwrt.org/docs/guide-developer/security#support_status