### PR TITLE
github: ALT p9 is EOL

### DIFF
--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -25,7 +25,6 @@ jobs:
         release:
           - Sisyphus
           - p10
-          - p9
         variant:
           - default
           - cloud


### PR DESCRIPTION
https://packages.altlinux.org/en/p9/about/:
> Support end date: Dec. 31, 2023