### PR TITLE
github: Void Linux only has a current release

### DIFF
--- a/.github/workflows/image-voidlinux.yml
+++ b/.github/workflows/image-voidlinux.yml
@@ -23,8 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - unstable
-          - 23.11
+          - current
         variant:
           - default
         architecture:


### PR DESCRIPTION
There doesn't seem to be any 23.11 release: https://mirrors.servercentral.com/voidlinux/live/

It has 2 variants (`default` (glibc) and `musl`) but we only provide the `default` one.