### PR TITLE
Out of space

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,6 +202,15 @@ jobs:
             [[ "${notes}" =~ disabled$ ]] && sudo snap remove "${name}" --revision "${rev}" --purge
           done || true
 
+          # Remove leftover home directories
+          sudo rm -rf /home/linuxbrew /home/runneradmin
+
+          # Remove unneeded directories
+          sudo rm -rf /opt/google/chrome
+          sudo rm -rf /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/Python
+          sudo rm -rf /opt/microsoft/msedge /opt/microsoft/msodbcsql* /opt/microsoft/powershell
+          sudo rm -rf /root/.sbt
+
           # This was inspired from https://github.com/easimon/maximize-build-space
           df -h
           # dotnet

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -115,7 +115,7 @@ for poolDriver in $poolDriverList; do
         lxc snapshot v1
         lxc copy v1 v2 --refresh
         [ "$(lxc query /1.0/instances/v2?recursion=1 | jq '.snapshots | length')" -eq "2" ]
-        lxc rm v1/snap1
+        lxc delete v1/snap1
         lxc delete -f v2
 
         echo "==> Checking running copied VM snapshot"
@@ -149,7 +149,7 @@ for poolDriver in $poolDriverList; do
         lxc snapshot v1
         lxc copy v1 localhost:v2 --refresh
         [ "$(lxc query /1.0/instances/v2?recursion=1 | jq '.snapshots | length')" -eq "2" ]
-        lxc rm v1/snap1
+        lxc delete v1/snap1
         lxc delete -f v2
 
         echo "==> Checking running migrated VM snapshot (same storage pool)"
@@ -187,7 +187,7 @@ for poolDriver in $poolDriverList; do
         lxc snapshot v1
         lxc copy v1 localhost:v2 --refresh -s "${poolName}2"
         [ "$(lxc query /1.0/instances/v2?recursion=1 | jq '.snapshots | length')" -eq "2" ]
-        lxc rm v1/snap1
+        lxc delete v1/snap1
         lxc delete -f v2
 
         echo "==> Checking running migrated VM snapshot (different storage pool)"

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -221,7 +221,7 @@ for poolDriver in $poolDriverList; do
         lxc delete v1/snap0
         lxc remote rm localhost
         lxc config trust rm "$(lxc query /1.0/certificates?recursion=1 | jq -r '.[].fingerprint')"
-        lxc storage rm "${poolName}2"
+        lxc storage delete "${poolName}2"
 
         echo "==> Check QEMU crash behavior and recovery"
         lxc exec v1 -- fsfreeze --freeze /


### PR DESCRIPTION
Frees up an additional ~11G on the rootfs.

This reduce the likelihood of running out of space during the storage tests.