### PR TITLE
Don't use `--accept-certificate` when consuming token

### DIFF
--- a/tests/container
+++ b/tests/container
@@ -129,12 +129,6 @@ for release in $RELEASES; do
     isSystemdClean n1 || ignore_known_issues "n1" "nesting"
     lxc exec n1 -- snap install lxd --channel="${LXD_SNAP_CHANNEL}"
     lxc exec n1 -- lxd init --auto
-
-    # 4.0/* doesn't have ubuntu-minimal remotes
-    if [ "$(lxc exec n1 -- lxc remote list -f csv | grep -cwF "minimal")" -lt 2 ]; then
-        lxc exec n1 -- lxc remote add ubuntu-minimal https://cloud-images.ubuntu.com/minimal/releases/ --protocol simplestreams || true
-        lxc exec n1 -- lxc remote add ubuntu-minimal-daily https://cloud-images.ubuntu.com/minimal/daily/ --protocol simplestreams || true
-    fi
     lxc exec n1 -- lxc launch "${IMAGE}" n11
     sleep 5
     [ "$(lxc exec n1 -- lxc exec n11 -- systemctl --quiet --failed)" = "" ] || ignore_known_issues "n11" "nested"

--- a/tests/container-copy
+++ b/tests/container-copy
@@ -28,7 +28,7 @@ lxc exec target -- lxd init --auto --network-address "[::]" --network-port "8443
 
 echo "==> Add the target VM as a remote LXD"
 token="$(lxc exec target -- lxc config trust add --name host --quiet)"
-lxc remote add target "${token}" --accept-certificate
+lxc remote add target "${token}"
 
 # Run the test for various filesystems.
 for fs in "xfs" "btrfs" "ext4" ; do

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -136,7 +136,7 @@ for poolDriver in $poolDriverList; do
         echo "==> Add current LXD as remote via localhost"
         lxc config set core.https_address=:8443
         token="$(lxc config trust add --name localhost --quiet)"
-        lxc remote add localhost "${token}" --accept-certificate
+        lxc remote add localhost "${token}"
 
         echo "==> Checking VM can be migrated with snapshots (same storage pool)"
         lxc copy v1 localhost:v2 --stateless


### PR DESCRIPTION
The whole point of using token is to avoid blindly trusting a random server certificate. IMHO, LXD should refuse this combo (https://github.com/canonical/lxd/issues/13973).