### PR TITLE
tests/storage-vm: don't wait before comparing VM gen IDs

### DIFF
--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -532,9 +532,7 @@ for poolDriver in $poolDriverList; do
         lxc profile delete vmsmall
 
         echo "==> Checking VM Generation UUID with QEMU"
-        lxc init "${IMAGE}" v1 --vm -s "${poolName}"
-        lxc start v1
-        waitInstanceReady v1
+        lxc launch "${IMAGE}" v1 --vm -s "${poolName}"
         lxc info v1
 
         # Check that the volatile.uuid.generation setting is applied to the QEMU process.


### PR DESCRIPTION
This saves ~20 seconds