### PR TITLE
Tests for disconnections during `lxc exec`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,6 +112,7 @@ jobs:
           - "storage-vm zfs"
           - storage-volumes-vm
           - tpm-vm
+          - vm
           - vm-migration
           - vm-nesting
         include:

--- a/tests/container
+++ b/tests/container
@@ -139,6 +139,7 @@ IMAGE="ubuntu-minimal-daily:24.04"
 
 echo "==> check that we can mount devpts and procfs in unprivileged container"
 lxc launch "${IMAGE}" u1
+waitInstanceBooted u1
 lxc exec u1 -- mkdir /root/proc
 lxc exec u1 -- mount -t proc proc /root/proc
 lxc exec u1 -- mkdir /root/devpts

--- a/tests/container
+++ b/tests/container
@@ -147,5 +147,13 @@ lxc exec u1 -- mkdir /root/sys
 lxc exec u1 -- mount -t sysfs sysfs /root/sys
 lxc delete -f u1
 
+
+echo "==> Try cleanly stopping a container"
+lxc launch "${IMAGE}" c1
+waitInstanceBooted c1
+lxc stop c1
+lxc start c1
+waitInstanceBooted c1
+
 # shellcheck disable=SC2034
 FAIL=0

--- a/tests/container
+++ b/tests/container
@@ -147,13 +147,30 @@ lxc exec u1 -- mkdir /root/sys
 lxc exec u1 -- mount -t sysfs sysfs /root/sys
 lxc delete -f u1
 
-
 echo "==> Try cleanly stopping a container"
 lxc launch "${IMAGE}" c1
 waitInstanceBooted c1
 lxc stop c1
 lxc start c1
 waitInstanceBooted c1
+
+echo "==> Test exit codes when container disconnects during lxc exec"
+
+# Try disconnecting a container stopping forcefully and gracefully to make sure they differ appropriately.
+(sleep 1 && lxc stop -f c1) &
+lxc exec c1 -- sleep 10 || exitCode=$?
+[ "${exitCode:-0}" -eq 137 ]
+
+wait $!
+lxc start c1
+waitInstanceBooted c1
+(sleep 1 && lxc stop c1) &
+lxc exec c1 -- sleep 10 || exitCode=$?
+# Both 129 and 143 have been seen and both make sense here.
+[ "${exitCode:-0}" -eq 129 ] || [ "${exitCode:-0}" -eq 143 ]
+
+wait $!
+lxc delete -f c1
 
 # shellcheck disable=SC2034
 FAIL=0

--- a/tests/vm
+++ b/tests/vm
@@ -16,6 +16,25 @@ waitInstanceBooted vm1
 echo "==> Test cleanly stopping a VM"
 lxc stop vm1
 
+if ! echo "${LXD_SNAP_CHANNEL}" | grep -qE '^4\.0/'; then
+    echo "==> Test lxc exec exit code upon VM disconnection due to a stop/reboot"
+    lxc start vm1
+    waitInstanceBooted vm1
+
+    # Try disconnecting a VM stopping forcefully and gracefully to make sure they match.
+    (sleep 1 && lxc stop -f vm1) &
+    lxc exec vm1 -- sleep 10 || exitCode=$?
+    [ "${exitCode:-0}" -eq 129 ]
+
+    wait $!
+    lxc start vm1
+    waitInstanceBooted vm1
+    (sleep 1 && lxc stop vm1) &
+    lxc exec vm1 -- sleep 10 || exitCode=$?
+    [ "${exitCode:-0}" -eq 129 ]
+    wait $!
+fi
+
 # Cleanup
 lxc delete -f vm1
 

--- a/tests/vm
+++ b/tests/vm
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eux
+
+# Install LXD
+install_lxd
+
+# Configure LXD
+lxd init --auto
+
+IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"
+
+# Launch test instance
+lxc launch "${IMAGE}" vm1 --vm
+waitInstanceBooted vm1
+
+echo "==> Test cleanly stopping a VM"
+lxc stop vm1
+
+# Cleanup
+lxc delete -f vm1
+
+# shellcheck disable=SC2034
+FAIL=0


### PR DESCRIPTION
As was discussed with @mihalicyn If containers are stopped gracefully, the exit code can be 129(SIGHUP) or 143(SIGTERM) depending on the signal used, both results have been seen and make sense. If forcefully stopping a container the exit code is always 137 (SIGKILL). For VMs, the exit code was standardized as 129 for all cases by [#13875](https://github.com/canonical/lxd/pull/13875) (not merged yet).

In its current state, this PR only adds tests for forcefully stopping containers and VMs.