### PR TITLE
images: Remove security.selinux extended attributes on CentOS images

### DIFF
--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -378,6 +378,16 @@ actions:
   releases:
   - 9-Stream
 
+- trigger: post-unpack
+  action: |-
+    #!/bin/sh
+    # Remove security.selinux xattr.
+    find / -xdev -exec setfattr -x security.selinux {} 2>/dev/null \;
+  types:
+  - container
+  releases:
+  - 9-Stream
+
 - trigger: post-packages
   action: |-
     #!/bin/sh


### PR DESCRIPTION
Removes xattr `security.selinux` on container CentOS 9-Stream images.

I've tried suggestion from @simondeziel with `+` at the end of the `find` command to process files in bulk, but it always resulted in an error - it may be that I've missed something. Feel free to improve.

Passing build on fork: https://github.com/MusicDin/lxd-ci/actions/runs/10745316648/job/29804098029