### PR TITLE
tests: Update devlxd request source identification

### DIFF
--- a/tests/devlxd-container
+++ b/tests/devlxd-container
@@ -114,7 +114,9 @@ kill -9 "${monitorPID}"
 
 # If the guest retrieved the image from the host, the host should emit an "image-retrieved" lifecycle event. The
 # requestor address tells us that this was definitely the guest.
-[ "$(grep -wF 'image-retrieved' monitor.json | jq -r '.metadata.requestor.address')" = "@devlxd" ]
+# Newer LXD versions use the protocol instead of the requestor address to distinguish devlxd requests
+[ "$(grep -wF 'image-retrieved' monitor.json | jq -r '.metadata.requestor.address')" = "@devlxd" ] || \
+  [ "$(grep -wF 'image-retrieved' monitor.json | jq -r '.metadata.requestor.protocol')" = "devlxd" ]
 rm monitor.json
 
 echo "==> Deleting container"

--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -124,7 +124,8 @@ if hasNeededAPIExtension devlxd_images_vm; then
 
   # If the guest retrieved the image from the host, the host should emit an "image-retrieved" lifecycle event. The
   # requestor address tells us that this was definitely the guest.
-  [ "$(grep -wF 'image-retrieved' monitor.json | jq -r '.metadata.requestor.address')" = "@devlxd" ]
+  [ "$(grep -wF 'image-retrieved' monitor.json | jq -r '.metadata.requestor.address')" = "@devlxd" ] || \
+    [ "$(grep -wF 'image-retrieved' monitor.json | jq -r '.metadata.requestor.protocol')" = "devlxd" ]
   rm monitor.json
 fi
 


### PR DESCRIPTION
This is needed because [#14056](https://github.com/canonical/lxd/pull/14056) changed how we identify a request as coming from the /dev/lxd socket. If version checking for 5.21 and after is needed here please let me know. Not sure how/if the metrics will be backported.