### PR TITLE
tests/qemu-external-vm: rework version based skipping

### DIFF
--- a/tests/qemu-external-vm
+++ b/tests/qemu-external-vm
@@ -9,8 +9,8 @@ if [ "${architecture}" != "x86_64" ]; then
   exit 0
 fi
 
-if ! echo "${LXD_SNAP_CHANNEL}" | grep -q '^latest/edge'; then
-  echo "Skipping test as should only run on latest/edge"
+if echo "${LXD_SNAP_CHANNEL}" | grep -q '^[45]\.'; then
+  echo "Skipping test on 4.0, 5.0 and 5.21 branches"
   # shellcheck disable=SC2034
   FAIL=0
   exit 0


### PR DESCRIPTION
Testing only on `latest/edge` means that we'll need to revisit the condition when the next LTS occurs. Let's do it now as we know what to skip already.