### PR TITLE
tests: Disable SELinux before exporting CentOS image

### DIFF
--- a/tests/conversion
+++ b/tests/conversion
@@ -122,7 +122,8 @@ conversion() {
     if [ "${instType}" = "vm" ]; then
         echo "==> TEST: Conversion: Import virtual-machine '${instName}' on '${poolType}' storage pool"
 
-        poolName="conversion-${poolType}"
+        instName="vm-${instName}-${poolType}"
+        poolName="pool-${instName}-${poolType}"
         hostAddr="127.0.0.1"
         instTypeCode="2" # VM in migration questioneer.
 
@@ -239,21 +240,21 @@ sed -i '/images\.lxd\.canonical\.com/d' /etc/hosts
 tmpdir="$(mktemp -d)"
 
 # Create an instance and export it to get raw image.
-lxc init images:alpine/edge vm-tmp --vm
-lxc export vm-tmp "${tmpdir}/vm-tmp.tar.gz"
-lxc delete vm-tmp
+lxc init images:alpine/edge tmp --vm
+lxc export tmp "${tmpdir}/tmp.tar.gz"
+lxc delete tmp
 
 # Extract raw image from exported backup.
-tar -xzf "${tmpdir}/vm-tmp.tar.gz" -C "${tmpdir}" "backup/virtual-machine.img"
-rm "${tmpdir}/vm-tmp.tar.gz"
+tar -xzf "${tmpdir}/tmp.tar.gz" -C "${tmpdir}" "backup/virtual-machine.img"
+rm "${tmpdir}/tmp.tar.gz"
 
 # Test VM migration using conversion mode. If server does not support
 # conversion API extension, lxd-migrate must fallback to migration
 # mode and successfully transfer the VM disk.
-conversion_vm vm-alpine-raw-btrfs btrfs "${tmpdir}/backup/virtual-machine.img" "no"
-conversion_vm vm-alpine-raw-lvm lvm "${tmpdir}/backup/virtual-machine.img" "no"
-conversion_vm vm-alpine-raw-zfs zfs "${tmpdir}/backup/virtual-machine.img" "no"
-conversion_vm vm-alpine-raw-dir dir "${tmpdir}/backup/virtual-machine.img" "no"
+conversion_vm alpine-raw btrfs "${tmpdir}/backup/virtual-machine.img" "no"
+conversion_vm alpine-raw lvm "${tmpdir}/backup/virtual-machine.img" "no"
+conversion_vm alpine-raw zfs "${tmpdir}/backup/virtual-machine.img" "no"
+conversion_vm alpine-raw dir "${tmpdir}/backup/virtual-machine.img" "no"
 rm -rf "${tmpdir}/backup"
 
 # Test VM conversion using non-raw disk formats only if server supports
@@ -263,26 +264,26 @@ if hasNeededAPIExtension instance_import_conversion; then
     IMAGE_PATH="${tmpdir}/image"
 
     lxc image export images:alpine/edge "${IMAGE_PATH}" --vm
-    conversion_vm vm-alpine-qcow2-zfs zfs "${IMAGE_PATH}.root" "no"
+    conversion_vm alpine-qcow2 zfs "${IMAGE_PATH}.root" "no"
 
     lxc image export images:centos/9-Stream "${IMAGE_PATH}" --vm
-    conversion_vm vm-centos9-qcow2-btrfs btrfs "${IMAGE_PATH}.root" "yes"
+    conversion_vm centos9-qcow2 btrfs "${IMAGE_PATH}.root" "yes"
 
     rm "${IMAGE_PATH}" "${IMAGE_PATH}.root"
 
     # Test VMDK image.
     wget -q -O "${IMAGE_PATH}" https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.vmdk
 
-    conversion_vm vm-u24-vmdk-dir dir "${IMAGE_PATH}" "yes"
-    conversion_vm vm-u24-vmdk-lvm lvm "${IMAGE_PATH}" "yes"
+    conversion_vm u24-vmdk dir "${IMAGE_PATH}" "yes"
+    conversion_vm u24-vmdk lvm "${IMAGE_PATH}" "yes"
 
     # Use custom volume for backups. Images for conversion will be uploaded here.
     lxc storage create backups-pool zfs
     lxc storage volume create backups-pool backups-vol
     lxc config set storage.backups_volume=backups-pool/backups-vol
 
-    conversion_vm vm-u24-vmdk-dir-bupvol dir "${IMAGE_PATH}" "yes"
-    conversion_vm vm-u24-vmdk-zfs-bupvol zfs "${IMAGE_PATH}" "yes"
+    conversion_vm u24-vmdk-bupvol dir "${IMAGE_PATH}" "yes"
+    conversion_vm u24-vmdk-bupvol zfs "${IMAGE_PATH}" "yes"
 
     # Test virtio conversion if virt-v2v-in-place is installed.
     if ! command -v virt-v2v-in-place > /dev/null; then
@@ -316,7 +317,7 @@ if hasNeededAPIExtension instance_import_conversion; then
         rm "${tmpdir}/vm.tar.gz"
 
         # Ensure that virtio conversion adds the needed virtio_scsi module back into the initramfs.
-        conversion_vm vm-centos-missing-driver zfs "${tmpdir}/backup/virtual-machine.img" "no" "virtio"
+        conversion_vm centos-missing-driver zfs "${tmpdir}/backup/virtual-machine.img" "no" "virtio"
     fi
 
     # Cleanup.

--- a/tests/conversion
+++ b/tests/conversion
@@ -297,9 +297,13 @@ if hasNeededAPIExtension instance_import_conversion; then
         # Afterwards, rebuild the initramfs image and stop the instance.
         lxc exec v1 -- rm /etc/dracut.conf.d/lxd.conf
         lxc exec v1 -- dracut --force --omit-drivers virtio_scsi
-        lxc stop v1
+
+        # XXX: Disable SELinux before exporting the instance, as it will block lxd-agent
+        # when re-imported.
+        lxc exec v1 -- sed -i "s/SELINUX=enforcing/SELINUX=disabled/" /etc/selinux/config
 
         # Export instance.
+        lxc stop v1
         lxc export v1 "${tmpdir}/vm.tar.gz"
 
         # Ensure instance does not boot without virtio_scsi drivers.


### PR DESCRIPTION
This is a temporary fix for conversion tests, and to allow me to test `lxd-migrate` in non-interactive mode (https://github.com/canonical/lxd-ci/pull/283). It also cleans up the instance and pool naming to reduce duplication.

Passing conversion tests on fork: https://github.com/MusicDin/lxd-ci/actions/runs/10937871555