### PR TITLE
tests/container: Add test to ensure launching an aliased container image won't launch with vm flag

### DIFF
--- a/tests/container
+++ b/tests/container
@@ -155,6 +155,10 @@ lxc stop c1
 lxc start c1
 waitInstanceBooted c1
 
+echo "==> Ensure aliased image won't launch with VM flag set"
+lxc image alias create containeralias "$(lxc config get c1 volatile.base_image)"
+! lxc launch containeralias --vm || false
+
 echo "==> Test exit codes when container disconnects during lxc exec"
 
 # Try disconnecting a container stopping forcefully and gracefully to make sure they differ appropriately.

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -612,7 +612,7 @@ for poolDriver in $poolDriverList; do
         lxc config set storage.images_volume "${poolName}"/images
         lxc publish v1 --alias v1image
         lxc delete v1
-        lxc launch v1image v2 -s "${poolName}"
+        lxc launch v1image v2 -s "${poolName}" # --vm flag omitted as we are implicitly launching a vm
         waitInstanceReady v2
         lxc delete -f v2
         lxc image delete v1image


### PR DESCRIPTION
- Launching an aliased container image shouldn't launch with the `--vm` flag; and
- VM's should be launched with `--vm` flag.