### PR TITLE
tests/conversion: SELinux is no longer in `images:centos/9-Stream`

### DIFF
--- a/tests/conversion
+++ b/tests/conversion
@@ -389,7 +389,9 @@ if hasNeededAPIExtension instance_import_conversion; then
 
         # XXX: Disable SELinux before exporting the instance, as it will block lxd-agent
         # when re-imported.
-        lxc exec v1 -- sed -i "s/SELINUX=enforcing/SELINUX=disabled/" /etc/selinux/config
+        if lxc exec v1 -- test -e /etc/selinux/config; then
+            lxc exec v1 -- sed -i "s/SELINUX=enforcing/SELINUX=disabled/" /etc/selinux/config
+        fi
 
         # Export instance and extract raw image.
         lxc stop v1


### PR DESCRIPTION
Rather than assume it is there or not, let's only disable it if the config file is present. This should keep it working even if SElinux is reintroduced in the image.