### PR TITLE
Fix tests/cgroup on cgroup2

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -248,6 +248,18 @@ cleanup() {
         uname -a
         lxc list --all-projects || lxc list
 
+        echo "::group::lsmod"
+        lsmod
+        echo "::endgroup::"
+
+        echo "::group::meminfo"
+        cat /proc/meminfo
+        echo "::endgroup::"
+
+        echo "::group::mountinfo"
+        cat /proc/1/mountinfo
+        echo "::endgroup::"
+
         # LXD daemon logs
         echo "::group::lxd logs"
         journalctl --quiet --no-hostname --no-pager --boot=0 --lines=100 --unit=snap.lxd.daemon.service

--- a/tests/cgroup
+++ b/tests/cgroup
@@ -22,7 +22,7 @@ lxc launch "${IMAGE}" c1
 echo "==> Validate default values"
 [ "$(lxc exec c1 -- nproc)" = "$(nproc)" ]
 [ "$(lxc exec c1 -- grep ^MemTotal /proc/meminfo)" = "$(grep ^MemTotal /proc/meminfo)" ]
-if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] || [ -e "/sys/fs/cgroup/memory.swap.max" ]; then
+if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] || [ -e "/sys/fs/cgroup/system.slice/memory.swap.max" ]; then
     [ "$(lxc exec c1 -- grep ^SwapTotal /proc/meminfo)" = "$(grep ^SwapTotal /proc/meminfo)" ]
 else
     [ "$(lxc exec c1 -- grep ^SwapTotal /proc/meminfo)" = "SwapTotal:             0 kB" ]
@@ -110,7 +110,7 @@ echo "==> Testing memory limits"
 MEM_LIMIT_MIB=512
 lxc config set c1 limits.memory="${MEM_LIMIT_MIB}MiB"
 [ "$(lxc exec c1 -- grep ^MemTotal /proc/meminfo)" = "MemTotal:         $((MEM_LIMIT_MIB * 1024)) kB" ]
-if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] || [ -e "/sys/fs/cgroup/memory.swap.max" ]; then
+if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] || [ -e "/sys/fs/cgroup/system.slice/memory.swap.max" ]; then
     [ "$(lxc exec c1 -- grep ^SwapTotal /proc/meminfo)" = "SwapTotal:        $((MEM_LIMIT_MIB * 1024)) kB" ]
 else
     [ "$(lxc exec c1 -- grep ^SwapTotal /proc/meminfo)" = "SwapTotal:             0 kB" ]
@@ -133,7 +133,7 @@ if [ -e "/sys/fs/cgroup/memory" ]; then
     [ "$(lxc exec c1 -- cat /sys/fs/cgroup/memory/memory.swappiness)" = "65" ]
 fi
 
-if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] || [ -e "/sys/fs/cgroup/memory.swap.max" ]; then
+if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] || [ -e "/sys/fs/cgroup/system.slice/memory.swap.max" ]; then
     lxc config set c1 limits.memory 128MiB
     [ "$(lxc exec c1 -- grep ^MemTotal /proc/meminfo)" = "MemTotal:         131072 kB" ]
 

--- a/tests/cgroup
+++ b/tests/cgroup
@@ -12,6 +12,13 @@ lxd init --auto
 
 IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"
 
+rc=0
+journalctl --quiet --no-hostname --no-pager --boot=0 --unit=snap.lxd.daemon.service | grep "Kernel supports swap accounting" || rc="$?"
+LXCFS_SUPPORTS_SWAP_ACCOUNTING=0
+if [ "${rc}" -eq 0 ]; then
+    LXCFS_SUPPORTS_SWAP_ACCOUNTING=1
+fi
+
 # Test
 set -x
 
@@ -22,7 +29,8 @@ lxc launch "${IMAGE}" c1
 echo "==> Validate default values"
 [ "$(lxc exec c1 -- nproc)" = "$(nproc)" ]
 [ "$(lxc exec c1 -- grep ^MemTotal /proc/meminfo)" = "$(grep ^MemTotal /proc/meminfo)" ]
-if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] || [ -e "/sys/fs/cgroup/system.slice/memory.swap.max" ]; then
+if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] ||
+   { [ -e "/sys/fs/cgroup/system.slice/memory.swap.max" ] && [ "${LXCFS_SUPPORTS_SWAP_ACCOUNTING}" -eq 1 ]; }; then
     [ "$(lxc exec c1 -- grep ^SwapTotal /proc/meminfo)" = "$(grep ^SwapTotal /proc/meminfo)" ]
 else
     [ "$(lxc exec c1 -- grep ^SwapTotal /proc/meminfo)" = "SwapTotal:             0 kB" ]
@@ -110,7 +118,8 @@ echo "==> Testing memory limits"
 MEM_LIMIT_MIB=512
 lxc config set c1 limits.memory="${MEM_LIMIT_MIB}MiB"
 [ "$(lxc exec c1 -- grep ^MemTotal /proc/meminfo)" = "MemTotal:         $((MEM_LIMIT_MIB * 1024)) kB" ]
-if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] || [ -e "/sys/fs/cgroup/system.slice/memory.swap.max" ]; then
+if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] ||
+   { [ -e "/sys/fs/cgroup/system.slice/memory.swap.max" ] && [ "${LXCFS_SUPPORTS_SWAP_ACCOUNTING}" -eq 1 ]; }; then
     [ "$(lxc exec c1 -- grep ^SwapTotal /proc/meminfo)" = "SwapTotal:        $((MEM_LIMIT_MIB * 1024)) kB" ]
 else
     [ "$(lxc exec c1 -- grep ^SwapTotal /proc/meminfo)" = "SwapTotal:             0 kB" ]
@@ -133,7 +142,8 @@ if [ -e "/sys/fs/cgroup/memory" ]; then
     [ "$(lxc exec c1 -- cat /sys/fs/cgroup/memory/memory.swappiness)" = "65" ]
 fi
 
-if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] || [ -e "/sys/fs/cgroup/system.slice/memory.swap.max" ]; then
+if [ -e "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes" ] ||
+   { [ -e "/sys/fs/cgroup/system.slice/memory.swap.max" ] && [ "${LXCFS_SUPPORTS_SWAP_ACCOUNTING}" -eq 1 ]; }; then
     lxc config set c1 limits.memory 128MiB
     [ "$(lxc exec c1 -- grep ^MemTotal /proc/meminfo)" = "MemTotal:         131072 kB" ]
 


### PR DESCRIPTION
When cgroup2 is used there is a difference between root of cgroupfs tree and sub-cgroups. When we do a cgroup feature checking we should check for `memory.swap.max` file existence in a `/sys/fs/cgroup/system.slice/memory.swap.max` instead of `/sys/fs/cgroup/memory.swap.max`.

See also:
https://github.com/lxc/lxcfs/commit/f496e62cdbeb01215af34fed266fc5a98d25feeb