### PR TITLE
images/kali: Fix enabling cloud-init service

### DIFF
--- a/images/kali.yaml
+++ b/images/kali.yaml
@@ -1774,7 +1774,7 @@ actions:
     set -eux
 
     # Enable cloud-init units
-    systemctl enable cloud-init
+    systemctl enable cloud-init-main
   variants:
   - cloud
 


### PR DESCRIPTION
When cloud-init is installed, the `systemctl enable cloud-init` fails. The service is now called `cloud-init-main`.

Passing build: https://github.com/MusicDin/lxd-ci/actions/runs/11165385223