### PR TITLE
Use `security.devlxd.images` with VMs where applicable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -239,6 +239,7 @@ jobs:
       # needed for cache key
       - name: Get Date
         id: get-date
+        if: ${{ matrix.test == 'qemu-external-vm' }}
         run: |
           echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash

--- a/bin/local-run
+++ b/bin/local-run
@@ -5,7 +5,7 @@ script="${1}"
 lxd_snap_channel="${2}"
 shift 2
 test_name="$(basename "${script}")"
-_script="$(mktemp "${test_name}.XXXX")"
+_script="$(mktemp -t "${test_name}.XXXX")"
 
 echo "==> Running the job ${test_name} against ${lxd_snap_channel}" >&2
 sed "1 r bin/helpers" "${script}" | sed "s|@@LXD_SNAP_CHANNEL@@$|LXD_SNAP_CHANNEL=${lxd_snap_channel}|" > "${_script}"

--- a/tests/cgroup
+++ b/tests/cgroup
@@ -12,10 +12,8 @@ lxd init --auto
 
 IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"
 
-rc=0
-journalctl --quiet --no-hostname --no-pager --boot=0 --unit=snap.lxd.daemon.service | grep "Kernel supports swap accounting" || rc="$?"
 LXCFS_SUPPORTS_SWAP_ACCOUNTING=0
-if [ "${rc}" -eq 0 ]; then
+if journalctl --quiet --no-hostname --no-pager --boot=0 --unit=snap.lxd.daemon.service --grep "Kernel supports swap accounting"; then
     LXCFS_SUPPORTS_SWAP_ACCOUNTING=1
 fi
 

--- a/tests/container-copy
+++ b/tests/container-copy
@@ -7,6 +7,9 @@ set -eu
 install_lxd
 lxd init --auto
 
+# Install dependencies
+install_deps btrfs-progs xfsprogs
+
 IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"
 
 echo "==> Create a loop device that we can mount as a source for a dir storage pool"

--- a/tests/container-copy
+++ b/tests/container-copy
@@ -24,7 +24,7 @@ waitInstanceBooted target
 
 echo "==> Setup LXD on the target VM"
 lxc exec target -- snap install lxd --channel "${LXD_SNAP_CHANNEL}"
-lxc exec target -- lxd init --auto --network-address "[::]" --network-port "8443"
+lxc exec target -- lxd init --auto --network-address "[::]" --network-port "8443" --storage-backend "zfs"
 
 echo "==> Add the target VM as a remote LXD"
 token="$(lxc exec target -- lxc config trust add --name host --quiet)"

--- a/tests/container-copy
+++ b/tests/container-copy
@@ -19,7 +19,7 @@ loopdev="$(losetup --show --find "${loopimg}")"
 set -x
 
 echo "==> Launch a VM which will be the target of the copy"
-lxc launch "${IMAGE}" target --vm
+lxc launch "${IMAGE}" target --vm -d root,size=8GiB
 waitInstanceBooted target
 
 echo "==> Setup LXD on the target VM"

--- a/tests/vm-migration
+++ b/tests/vm-migration
@@ -54,8 +54,14 @@ for _ in $(seq 60); do
 done
 
 # Launch two instances for our LXD cluster and wait for them to be ready.
-lxc launch "${TEST_IMG:-ubuntu-minimal-daily:24.04}" member1 --vm -c limits.memory=2GiB
-lxc launch "${TEST_IMG:-ubuntu-minimal-daily:24.04}" member2 --vm -c limits.memory=2GiB
+lxc init "${TEST_IMG:-ubuntu-minimal-daily:24.04}" member1 --vm -c limits.memory=2GiB
+lxc init "${TEST_IMG:-ubuntu-minimal-daily:24.04}" member2 --vm -c limits.memory=2GiB
+if hasNeededAPIExtension devlxd_images_vm; then
+    lxc config set member1 security.devlxd.images=true
+    lxc config set member2 security.devlxd.images=true
+fi
+lxc start member1
+lxc start member2
 waitInstanceReady member1
 waitInstanceReady member2
 # shellcheck disable=SC3044 # Ignore "declare is undefined" shellcheck error.

--- a/tests/vm-nesting
+++ b/tests/vm-nesting
@@ -102,6 +102,9 @@ delete "${VMs}"
 
 echo "==> Test ${nestedVMs} VMs each with one nested VM"
 init "${nestedVMs}" --vm
+if hasNeededAPIExtension devlxd_images_vm; then
+    conf "${nestedVMs}" security.devlxd.images=true
+fi
 start "${nestedVMs}"
 wait "${nestedVMs}"
 cmd "${nestedVMs}" "snap wait system seed.loaded && snap install lxd --channel ${LXD_SNAP_CHANNEL}"


### PR DESCRIPTION
This includes a few small unrelated tweaks.