### PR TITLE
Date handling on weekly news

### DIFF
--- a/news/README.md
+++ b/news/README.md
@@ -8,3 +8,4 @@ To generate a weekly news template, replace `<from_date>` and `<to_date>` with d
 ```sh
 weekly-changes.sh <from_date> <to_date>
 ```
+If <to-date> is not provided, the script will grab the day six days after <from_date>, as it would be if the interval was from Monday to Sunday.

--- a/news/weekly-changes.sh
+++ b/news/weekly-changes.sh
@@ -2,9 +2,32 @@
 
 set -e
 
-# Always from Monday to Sunday.
+# Set locale time for consistent month names
+export LC_TIME="C"
+
+date_to_text() {
+    # Extract day and month from the date
+    day=$(date -d "$1" +"%d")
+    month=$(date -d "$1" +"%B")
+
+    # Remove leading zeros from the day
+    day=$((10#$day))
+
+    # Determine the appropriate suffix for the day
+    case $day in
+    1|21|31) suffix="st" ;;
+    2|22) suffix="nd" ;;
+    3|23) suffix="rd" ;;
+    *) suffix="th" ;;
+    esac
+
+    # Return the result in the format "Nth of MonthName"
+    echo "${day}${suffix} ${month}"
+}
+
+# If end date not provided, assume Monday to Sunday.
 DATESTART=$1 # YYYY-MM-DD
-DATEEND=$2 # YYYY-MM-DD
+DATEEND=${2:-"$(date -d "$1 + 6 days" +"%Y-%m-%d")"} # YYYY-MM-DD
 
 if [ "${DATESTART}" = "" ] || [ "${DATEEND}" = "" ]; then
     echo "Usage: $0 <date_start> <date_end>"
@@ -14,7 +37,7 @@ fi
 #
 # Template that needs to be populated.
 #
-echo '**Weekly status for the week of <DD>th <MM> to <DD>th <MM>.**'
+echo "**Weekly status for the week of $(date_to_text "${DATESTART}") to $(date_to_text "${DATEEND}").**"
 
 echo -e "\n# Introduction"
 echo -e "\nA few sentences summarizing this week."
@@ -38,21 +61,18 @@ echo -e "\n## All changes"
 echo -e "\nThe items listed below is all of the work which happened over the past week and which will be included in the next release."
 
 echo -e "\n## LXD"
-./github-issues.py canonical/lxd "${1}" "${2}"
+./github-issues.py canonical/lxd "${DATESTART}" "${DATEEND}"
 sleep 1
 
 echo -e "\n## LXD UI"
-./github-issues.py canonical/lxd-ui "${1}" "${2}"
+./github-issues.py canonical/lxd-ui "${DATESTART}" "${DATEEND}"
 sleep 1
 
 echo -e "\n## LXD Charm"
-./github-issues.py canonical/charm-lxd "${1}" "${2}"
-
-echo -e "\n## LXD Terraform provider"
-./github-issues.py terraform-lxd/terraform-provider-lxd "${1}" "${2}"
+./github-issues.py canonical/charm-lxd "${DATESTART}" "${DATEEND}"
 
 echo -e "\n## PyLXD"
-./github-issues.py canonical/pylxd "${1}" "${2}"
+./github-issues.py canonical/pylxd "${DATESTART}" "${DATEEND}"
 
 echo -e "\n# Distribution work"
 echo -e "\nThis section is used to track the work done in downstream Linux distributions to ship the latest LXD as well as work to get various software to work properly inside containers."
@@ -61,4 +81,4 @@ echo -e "\n## Ubuntu"
 echo -e "* Nothing to report this week."
 
 echo -e "\n## LXD snap"
-./github-issues.py canonical/lxd-pkg-snap "${1}" "${2}"
+./github-issues.py canonical/lxd-pkg-snap "${DATESTART}" "${DATEEND}"


### PR DESCRIPTION
I was messing with this the other day and thought this could be useful :D

This does two things:
- Fills the dates on the output of `weekly-changes.sh`
- If the second date is not provided, assume a Monday to Sunday interval (6 days after the first date)