### PR TITLE
Revert "tests/vm-nesting: use security.devlxd.images with VMs if supp…

### DIFF
--- a/tests/vm-nesting
+++ b/tests/vm-nesting
@@ -102,9 +102,6 @@ delete "${VMs}"
 
 echo "==> Test ${nestedVMs} VMs each with one nested VM"
 init "${nestedVMs}" --vm
-if hasNeededAPIExtension devlxd_images_vm; then
-    conf "${nestedVMs}" security.devlxd.images=true
-fi
 start "${nestedVMs}"
 wait "${nestedVMs}"
 cmd "${nestedVMs}" "snap wait system seed.loaded && snap install lxd --channel ${LXD_SNAP_CHANNEL}"


### PR DESCRIPTION
…orted"

This reverts commit 1a68605c4a63da12ab2cc8e170b18a88e0a79cf7.