### PR TITLE
Improve testing a stop in the middle of lxc exec

### DIFF
--- a/tests/container
+++ b/tests/container
@@ -159,22 +159,26 @@ echo "==> Ensure aliased image won't launch with VM flag set"
 lxc image alias create containeralias "$(lxc config get c1 volatile.base_image)"
 ! lxc launch containeralias --vm || false
 
-echo "==> Test exit codes when container disconnects during lxc exec"
+echo "==> Test getting the correct exit code for a signaled process"
+# Signaling the process spawned by lxc exec and checking its exit code.
+# Simulates what can happen if the container stops cleanly in the middle of lxc exec.
+for signal in SIGTERM SIGHUP SIGTERM; do
+    echo "==> Test getting the correct exit code when sending ${signal} to an exec'ed process"
+    code="$(kill -l "${signal}")"
+    # killall is not included in minimal images so we use escaping to combine pgrep and kill.
+    (sleep 5 && lxc exec c1 -- bash -c "kill -s ${signal} \$(pgrep sleep)") &
+    lxc exec c1 -- sleep 60 || exitCode=$?
+    # Check exit code, should be 128 plus signal number, 1 for SIGHUP, 9 for SIGKILL and 15 for SIGTERM.
+    [ "${exitCode:-0}" -eq $((128 + code)) ]
+done
 
+echo "==> Test exit codes when container disconnects during lxc exec"
 # Try disconnecting a container stopping forcefully and gracefully to make sure they differ appropriately.
 (sleep 1 && lxc stop -f c1) &
 lxc exec c1 -- sleep 10 || exitCode=$?
 [ "${exitCode:-0}" -eq 137 ]
-
 wait $!
-lxc start c1
-waitInstanceBooted c1
-(sleep 1 && lxc stop c1) &
-lxc exec c1 -- sleep 10 || exitCode=$?
-# Both 129 and 143 have been seen and both make sense here.
-[ "${exitCode:-0}" -eq 129 ] || [ "${exitCode:-0}" -eq 143 ]
 
-wait $!
 lxc delete -f c1
 
 # shellcheck disable=SC2034

--- a/tests/vm
+++ b/tests/vm
@@ -21,15 +21,20 @@ if ! echo "${LXD_SNAP_CHANNEL}" | grep -qE '^4\.0/'; then
     lxc start vm1
     waitInstanceBooted vm1
 
-    echo "==> Test lxc exec exit code when stopping the VM cleanly"
-    (sleep 5 && lxc stop vm1) &
-    lxc exec vm1 -- sleep 60 || exitCode=$?
-    [ "${exitCode:-0}" -eq 129 ]
-    wait $!
+    echo "==> Test getting the correct exit code for a signaled process"
+    # Signaling the process spawned by lxc exec and checking its exit code.
+    # Simulates what can happen if the container stops in the middle of lxc exec.
+    for signal in SIGTERM SIGHUP SIGTERM; do
+        echo "==> Test getting the correct exit code when sending ${signal} to an exec'ed process"
+        code="$(kill -l "${signal}")"
+        # killall is not included in minimal images so we use escaping to combine pgrep and kill.
+        (sleep 5 && lxc exec vm1 -- bash -c "kill -s ${signal} \$(pgrep sleep)") &
+        lxc exec vm1 -- sleep 60 || exitCode=$?
+        # Check exit code, should be 128 plus signal number, 1 for SIGHUP, 9 for SIGKILL and 15 for SIGTERM.
+        [ "${exitCode:-0}" -eq $((128 + code)) ]
+    done
 
     echo "==> Test lxc exec exit code when stopping the VM abruptly"
-    lxc start vm1
-    waitInstanceBooted vm1
     (sleep 5 && lxc stop -f vm1) &
     lxc exec vm1 -- sleep 60 || exitCode=$?
     [ "${exitCode:-0}" -eq 129 ]

--- a/tests/vm
+++ b/tests/vm
@@ -39,6 +39,14 @@ if ! echo "${LXD_SNAP_CHANNEL}" | grep -qE '^4\.0/'; then
     lxc exec vm1 -- sleep 60 || exitCode=$?
     [ "${exitCode:-0}" -eq 129 ]
     wait $!
+
+    echo "==> Test what happens when the connection with the agent is severed"
+    lxc start vm1
+    waitInstanceBooted vm1
+    # Simulates what happens during lxc stop.
+    # killall is not included in minimal images so we use escaping to combine pgrep and kill.
+    lxc exec vm1 -- bash -c "kill -s SIGTERM \$(pgrep lxd-agent)" || exitCode=$?
+    [ "${exitCode:-0}" -eq 129 ]
 fi
 
 # Cleanup


### PR DESCRIPTION
When cleanly stopping a VM in the middle of lxc exec, two things can happen:
 1- The agent is stopped first, in which case the connection with LXD is severed and we are supposed to get a 129 exit code on the client;
 2- The spawned process is stopped first and the agent is able to respond before it also stops. In this case, we are supposed to get the exit code based on the signal that was used to stop the process;
 
 This adds tests for these two scenarios separately.