### PR TITLE
github: abort system-tests after 60 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,8 @@ jobs:
   system-tests:
     name: ${{ matrix.test }} (${{ matrix.track }} - ${{ matrix.os }})
     runs-on: ubuntu-${{ matrix.os }}
+    # avoid runaway test burning 6 hours of CI
+    timeout-minutes: 60
     permissions:
       # need that to manipulate caches
       actions: write


### PR DESCRIPTION
Out of the blue, `tests/vm-nesting` became our biggest [CI consumer](https://github.com/canonical/lxd-ci/actions/metrics/usage?tab=jobs). This was because at some point, that test simply stopped making progress so instead of taking < 15 minutes it would hang for 6 hours and eventually be [cancelled due to timeout](https://github.com/canonical/lxd-ci/actions/runs/11282145005/job/31379018916#step:9:3258).

Our current slowest test is `tests/storage-lvm` when ran on `24.04` and even this very slow combo finishes inside ~45 minutes. Allowing up to twice as long before timing out should provide enough headroom while also limiting the CI waste if a similar hang ever appears again.