### PR TITLE
bin/test-image: check if cloud-init cmd is available on non-cloud variants

### DIFF
--- a/bin/test-image
+++ b/bin/test-image
@@ -84,7 +84,7 @@ if [ "${TYPE}" = "vm" ]; then
     INSTANCES="${TEST_IMAGE}"
 
     # Cloud-init testing.
-    if [ "${VARIANT}" = "cloud" ]; then
+    if [ "${VARIANT}" = "cloud" ] || lxc exec "${name}" -- sh -c "command -v cloud-init"; then
         lxc config set "${TEST_IMAGE}" user.user-data "$(cat << EOF
 #cloud-config
 write_files:


### PR DESCRIPTION
This is mainly to enable the cloud-init testing of desktop images for which we only build a single variant called `desktop`.