### PR TITLE
images/arch: Fix cloud-init enabled service

### DIFF
--- a/images/archlinux.yaml
+++ b/images/archlinux.yaml
@@ -824,7 +824,7 @@ actions:
     #!/bin/sh
     set -eux
 
-    systemctl enable cloud-init-local.service cloud-init.service cloud-config.service cloud-final.service
+    systemctl enable cloud-init-local.service cloud-init-main.service cloud-config.service cloud-final.service
   variants:
   - cloud
   architectures:


### PR DESCRIPTION
Instead of enabling `cloud-init.service` enable `cloud-init-main.service`.