### PR TITLE
tests: Add testing for successful forward creation using an OVN network's own volatile IP

### DIFF
--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -854,11 +854,19 @@ EOF
     dig aaaa +tcp @2001:db8:1:2::1 u2.lxd
 
     echo "==> Check a forward cannot conflict with the volatile IP of other OVN networks on the same uplink"
+    ip4VolatileIP=$(lxc network get ovn-virtual-network volatile.network.ipv4.address)
+    ip6VolatileIP=$(lxc network get ovn-virtual-network volatile.network.ipv6.address)
     ip4VolatileIP2=$(lxc network get ovn-virtual-network2 volatile.network.ipv4.address)
     ip6VolatileIP2=$(lxc network get ovn-virtual-network2 volatile.network.ipv6.address)
-    lxc network set lxdbr0 ipv4.routes="${ip4VolatileIP2}/32" ipv6.routes="${ip6VolatileIP2}/128" --project=default
+    lxc network set lxdbr0 ipv4.routes="${ip4VolatileIP}/32,${ip4VolatileIP2}/32" ipv6.routes="${ip6VolatileIP}/128,${ip6VolatileIP2}/128" --project=default
+
+    # Forward creation should fail using a different OVN network's volatile IP
     ! lxc network forward create ovn-virtual-network "${ip4VolatileIP2}" || false
     ! lxc network forward create ovn-virtual-network "${ip6VolatileIP2}" || false
+
+    # Forward creation should succeed using a network's own volatile IP
+    lxc network forward create ovn-virtual-network "${ip4VolatileIP}"
+    lxc network forward create ovn-virtual-network "${ip6VolatileIP}"
 
     echo "==> Check network forwards are removed when network is removed"
     [ "$(ovn-nbctl list load_balancer | grep -cF name)" = 6 ]


### PR DESCRIPTION
This PR adds checks to ensure that network forwards can be created using an OVN network's own volatile IP.

Addresses https://github.com/canonical/lxd-ci/pull/333#discussion_r1823123705.