### PR TITLE
Cleanup unused images

### DIFF
--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -25,7 +25,6 @@ jobs:
         release:
           - Sisyphus
           - p11
-          - p10
         variant:
           - default
           - cloud

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -3,22 +3,17 @@ name: Build Devuan Images
 on:
   schedule:
     - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 jobs:
   devuan:
     if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
-    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +24,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - 'amd64'
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-funtoo.yml
+++ b/.github/workflows/image-funtoo.yml
@@ -3,22 +3,17 @@ name: Build Funtoo Images
 on:
   schedule:
     - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 jobs:
   funtoo:
     if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
-    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +22,7 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - 'amd64'
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -3,22 +3,17 @@ name: Build Gentoo Images
 on:
   schedule:
     - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 jobs:
   gentoo:
     if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
-    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +23,7 @@ jobs:
           - openrc
           - systemd
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - 'amd64'
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -3,33 +3,27 @@ name: Build openEuler Images
 on:
   schedule:
     - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 jobs:
   openeuler:
     if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
-    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
         release:
-          - 22.03
           - 24.03
         variant:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - 'amd64'
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -33,6 +33,7 @@ jobs:
           - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
         exclude:
           - {architecture: arm64, release: 7}
+          - {architecture: arm64, release: 8}
     env:
       type: "container"
       distro: "${{ github.job }}"


### PR DESCRIPTION
With @simondeziel we have checked the metrics for images, and this PR drops builds for unused images, especially focusing on distributions that are very *heavy* to build, such as Funtoo, and openEuler.

This removes builds for:
- Devuano (arm64 only)
- Gentoo (arm64 only)
- Funtoo (arm64 only)
- openEuler 22.03 (all)
- openEuler 24.03 (arm64 only)
- Oracle 8 (arm64 only)
- ALT p10 (all)