### PR TITLE
images/almalinux: update download source

### DIFF
--- a/images/almalinux.yaml
+++ b/images/almalinux.yaml
@@ -6,7 +6,7 @@ simplestream:
 
 source:
   downloader: almalinux-http
-  url: https://mirror.csclub.uwaterloo.ca/almalinux
+  url: https://repo.almalinux.org/almalinux/9/isos/x86_64/
   keys:
   # RPM-GPG-KEY-AlmaLinux-8
   - |-


### PR DESCRIPTION
The uwaterloo.ca mirror lost the `/almalinux/9/isos/x86_64/` dir it seems. Their primary download location has it still.