### PR TITLE
images/openwrt: Use apk as package manager

### DIFF
--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -51,9 +51,15 @@ jobs:
           [ "${ARCH}" = "amd64" ] && IMAGE_ARCH="x86_64"
           [ "${ARCH}" = "arm64" ] && IMAGE_ARCH="aarch64"
 
+          EXTRA_ARGS=""
+          if [ "${{ matrix.release }}" = "23.05" ]; then
+              EXTRA_ARGS="-o packages.manager=opkg"
+          fi
+
           ./bin/build-distro "${YAML}" "${ARCH}" "${TYPE}" "${TIMEOUT}" "${{ env.target }}" \
               -o image.architecture="${IMAGE_ARCH}" \
-              -o image.release=${{ matrix.release }}
+              -o image.release=${{ matrix.release }} \
+              ${EXTRA_ARGS}
 
       - name: Print build artifacts
         run: ls -lah "${{ env.target }}"

--- a/images/openwrt.yaml
+++ b/images/openwrt.yaml
@@ -234,6 +234,3 @@ actions:
     sed -i 's/procd_add_jail/: \0/g' /etc/init.d/dnsmasq
     # Disable conflicting sysntpd service to avoid crash loop
     rm -f /etc/rc.d/*sysntpd
-  releases:
-  - snapshot
-  - 23.05

--- a/images/openwrt.yaml
+++ b/images/openwrt.yaml
@@ -206,13 +206,16 @@ files:
         option proto 'dhcpv6'
 
 packages:
-  manager: opkg
+  # Note: Older releases of OpenWrt use "opkg" package manager.
+  manager: apk
   update: false
   cleanup: true
   sets:
   - packages:
     - sudo
     action: install
+    releases:
+    - 23.05
 
 actions:
 - trigger: post-unpack


### PR DESCRIPTION
Recently, openWRT changed their package manager from "opkg" to "apk" (Alpine Linux package manager).

Post from openWRT forum: https://forum.openwrt.org/t/the-future-is-now-opkg-vs-apk/201164

Passing build: https://github.com/MusicDin/lxd-ci/actions/runs/11940145394/job/33282183927