### PR TITLE
tests/cluster: Test for container stop after snap channel upgrade

### DIFF
--- a/tests/cluster
+++ b/tests/cluster
@@ -188,6 +188,10 @@ if [ "${TEST_RESTRICTED}" = "1" ]; then
     lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -er '.projects[0] == "default"'
 fi
 
+echo "==> Check container can be stopped after upgrade (checks for stop hook notification functionality)"
+lxc exec "${PREFIX}-1" -- lxc stop --force u1
+lxc exec "${PREFIX}-1" -- lxc stop --force u2
+
 echo "==> Deleting the cluster"
 for i in $(seq "${SIZE}"); do
     print_log "${PREFIX}-$i"


### PR DESCRIPTION
This allows us to test for container stop support after upgrading between core snap versions.