### PR TITLE
images/alt: Remove cloud-init workaround

### DIFF
--- a/images/alt.yaml
+++ b/images/alt.yaml
@@ -182,17 +182,5 @@ actions:
   variants:
   - cloud
 
-# XXX: Prevent cloud-init from attempting to modify the hostname. Otherwise, cloud-init fails with
-# an attribute error: "module 'cloudinit.util' has no attribute 'load_file'") in "update_hostname".
-- trigger: post-packages
-  action: |-
-    #!/bin/sh
-    set -eux
-
-    # Disable the update_hostname module in cloud-init.
-    sed -i '/update_hostname/d' /etc/cloud/cloud.cfg
-  variants:
-  - cloud
-
 mappings:
   architecture_map: altlinux


### PR DESCRIPTION
The issue with ALT cloud-init was fixed in the downstream as reported back by @holmanb in https://github.com/canonical/lxd-ci/pull/344#issuecomment-2545825708 (See [Bug in downstream altlinux](https://bugzilla.altlinux.org/52029)). This PR removes the previously introduced workaround.

Passing build: https://github.com/MusicDin/lxd-ci/actions/runs/12355203098/job/34478274649