### PR TITLE
tests/vm-migration: collect logs in case of migration failure

### DIFF
--- a/tests/vm-migration
+++ b/tests/vm-migration
@@ -135,7 +135,13 @@ sleep 60
 [ "$(lxc exec member1 -- lxc list -c L -f csv v1)" = "member1" ]
 
 # Move the VM to member2 but with a timeout as this sometimes hangs indefinitely but when it works it's fast.
-lxc exec member1 -- timeout 600 lxc move v1 --target member2
+if ! lxc exec member1 -- timeout 600 lxc move v1 --target member2; then
+    # Collect logs in case of failure
+    lxc exec member1 -- lxc list
+    lxc exec member1 -- journalctl -n 10 -u snap.lxd.daemon.service
+    lxc exec member2 -- journalctl -n 10 -u snap.lxd.daemon.service
+    false
+fi
 
 # Verify the migration did succeeded and the VM is running on member2.
 [ "$(lxc exec member1 -- lxc list -c L -f csv v1)" = "member2" ]


### PR DESCRIPTION
Locally, the migration currently fails due to the config drive using the `9p` fallback:

```
root@v1:~/lxd-ci# lxc exec member1 -- journalctl -n 5 -u snap.lxd.daemon.service
Dec 19 18:04:58 member1 lxd.daemon[1974]: time="2024-12-19T18:04:58Z" level=error msg="Failed to get leader cluster member address" err="Failed to get the address of the cluster leader: Server is not clustered"
Dec 19 18:04:58 member1 lxd.daemon[1974]: time="2024-12-19T18:04:58Z" level=error msg="Failed to get leader cluster member address" err="Failed to get the address of the cluster leader: Server is not clustered"
Dec 19 18:04:58 member1 lxd.daemon[1974]: time="2024-12-19T18:04:58Z" level=warning msg="Failed adding member event listener client" err="dial tcp 0.0.0.0:443: connect: connection refused" local="10.87.127.236:8443" remote=0.0.0.0
Dec 19 18:04:58 member1 lxd.daemon[1974]: time="2024-12-19T18:04:58Z" level=warning msg="Dqlite last entry" index=0 term=0
Dec 19 18:07:05 member1 lxd.daemon[1974]: time="2024-12-19T18:07:05Z" level=warning msg="Unable to use virtio-fs for config drive, using 9p as a fallback" err="Stateful migration unsupported" instance=v1 instanceType=virtual-machine project=default
```

Collecting logs on failure should help confirm if that's the same problem in CI.