### PR TITLE
Revert "github: add Fedora 41"

### DIFF
--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         release:
           - 40
-          - 41
         variant:
           - default
           - cloud


### PR DESCRIPTION
This reverts commit 8d57a1c5a243dd1f09e7125a4a3af961f1d14343 due to https://github.com/canonical/lxd/issues/14711