### PR TITLE
Oracle7 no longer supported without support contract ($)

### DIFF
--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 7  # Requires cgroups v1 for tests. They will pass on ubuntu-20.04 runner.
           - 8
           - 9
         variant:
@@ -32,7 +31,6 @@ jobs:
         architecture:
           - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
         exclude:
-          - {architecture: arm64, release: 7}
           - {architecture: arm64, release: 8}
     env:
       type: "container"

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   oracle:
     if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
-    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-20.04' }}
+    runs-on: ${{ matrix.architecture == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/images/oracle.yaml
+++ b/images/oracle.yaml
@@ -1,14 +1,6 @@
 image:
   distribution: oracle
 
-simplestream:
-  requirements:
-  - requirements:
-      cgroup: v1
-    releases:
-    - 7
-
-
 source:
   downloader: oraclelinux-http
   url: https://mirrors.kernel.org/oracle/
@@ -50,37 +42,6 @@ files:
 - name: hosts
   path: /etc/hosts
   generator: hosts
-
-- name: ifcfg-eth0
-  path: /etc/sysconfig/network-scripts/ifcfg-eth0
-  generator: dump
-  templated: true
-  content: |-
-    DEVICE=eth0
-    BOOTPROTO=dhcp
-    ONBOOT=yes
-    HOSTNAME=LXC_NAME
-    NM_CONTROLLED=no
-    TYPE=Ethernet
-    MTU=
-    DHCP_HOSTNAME=`hostname`
-  releases:
-  - 7
-
-- name: ifcfg-eth0.lxd
-  path: /etc/sysconfig/network-scripts/ifcfg-eth0
-  generator: template
-  content: |-
-    DEVICE=eth0
-    BOOTPROTO=dhcp
-    ONBOOT=yes
-    HOSTNAME={{ container.name }}
-    NM_CONTROLLED=no
-    TYPE=Ethernet
-    MTU=
-    DHCP_HOSTNAME=`hostname`
-  releases:
-  - 7
 
 - name: ifcfg-eth0
   path: /etc/sysconfig/network-scripts/ifcfg-eth0
@@ -185,13 +146,6 @@ packages:
   update: true
   cleanup: true
   sets:
-  - packages:
-    - rsyslog
-    - tcp_wrappers-libs
-    action: install
-    releases:
-    - 7
-
   - packages:
     - attr
     - curl

--- a/images/oracle.yaml
+++ b/images/oracle.yaml
@@ -55,9 +55,6 @@ files:
     TYPE=Ethernet
     MTU=
     DHCP_HOSTNAME=`cat /proc/sys/kernel/hostname`
-  releases:
-  - 8
-  - 9
 
 - name: ifcfg-eth0.lxd
   path: /etc/sysconfig/network-scripts/ifcfg-eth0
@@ -71,9 +68,6 @@ files:
     MTU=
     DHCP_HOSTNAME=`cat /proc/sys/kernel/hostname`
     IPV6INIT=yes
-  releases:
-  - 8
-  - 9
 
 - name: network
   path: /etc/sysconfig/network
@@ -109,9 +103,6 @@ files:
             control: auto{% else %}{{ config_get("user.network-config", "") }}{% endif %}
   variants:
   - cloud
-  releases:
-  - 8
-  - 9
 
 - name: user-data
   generator: cloud-init
@@ -137,9 +128,6 @@ files:
         distro: fedora
   variants:
   - cloud
-  releases:
-  - 8
-  - 9
 
 packages:
   manager: yum
@@ -163,9 +151,6 @@ packages:
   - packages:
     - NetworkManager
     action: install
-    releases:
-    - 8
-    - 9
 
   - packages:
     - cloud-init
@@ -184,9 +169,6 @@ packages:
       enabled=1
       gpgcheck=1
       gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
-    releases:
-    - 8
-    - 9
     variants:
     - cloud
 


### PR DESCRIPTION
https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf:
> Premier Support Ends on Dec 2024 for Oracle 7

https://www.oracle.com/a/ocom/docs/linux/oracle-linux-extended-support-ds.pdf:
> Oracle Linux Basic and Premier Support are available for 10 years after the initial release of every version of Oracle
Linux, Red Hat Enterprise Linux (RHEL), and CentOS Linux1. This is the production support period. After this period,
Oracle Linux Extended Support is available for a number of years, depending upon the release and version2. Oracle
Linux Extended Support requires an underlying Oracle Linux Premier Support contract.