### PR TITLE
Test `virtiofsd` bug workaround

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,8 +81,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(inputs.ubuntu-releases || '["20.04", "22.04", "24.04"]') }}
-        track: ${{ fromJSON(inputs.snap-tracks || '["latest/edge", "5.21/edge", "5.0/edge", "4.0/edge"]') }}
+        os: ${{ fromJSON(inputs.ubuntu-releases || '["22.04", "24.04"]') }}
+        track: ${{ fromJSON(inputs.snap-tracks || '["latest/edge"]') }}
         test:
           - cgroup
           - cloud-init
@@ -117,150 +117,10 @@ jobs:
           - vm
           - vm-migration
           - vm-nesting
-        exclude:
-          # not compatible with 4.0/*
-          - test: cloud-init
-            track: "4.0/candidate"
-          - test: container-copy
-            track: "4.0/candidate"
-          - test: conversion
-            track: "4.0/candidate"
-          - test: cpu-vm
-            track: "4.0/candidate"
-          - test: devlxd-vm
-            track: "4.0/candidate"
-          - test: efi-vars-editor-vm
-            track: "4.0/candidate"
-          - test: lxd-user
-            track: "4.0/candidate"
-          - test: network-bridge-firewall
-            track: "4.0/candidate"
-            os: 20.04
-          - test: network-ovn ovn:deb
-            track: "4.0/candidate"
-          - test: network-ovn ovn:latest/edge
-            track: "4.0/candidate"
+        include:
           - test: qemu-external-vm
-            track: "4.0/candidate"
-          - test: storage-buckets
-            track: "4.0/candidate"
-          - test: storage-disks-vm
-            track: "4.0/candidate"
-          - test: storage-vm btrfs
-            track: "4.0/candidate"
-          - test: storage-vm ceph
-            track: "4.0/candidate"
-          - test: storage-vm dir
-            track: "4.0/candidate"
-          - test: storage-vm lvm
-            track: "4.0/candidate"
-          - test: storage-vm lvm-thin
-            track: "4.0/candidate"
-          - test: storage-vm zfs
-            track: "4.0/candidate"
-          - test: storage-volumes-vm
-            track: "4.0/candidate"
-          - test: tpm-vm
-            track: "4.0/candidate"
-          - test: vm-migration
-            track: "4.0/candidate"
-          - test: cloud-init
-            track: "4.0/edge"
-          - test: container-copy
-            track: "4.0/edge"
-          - test: conversion
-            track: "4.0/edge"
-          - test: cpu-vm
-            track: "4.0/edge"
-          - test: devlxd-vm
-            track: "4.0/edge"
-          - test: efi-vars-editor-vm
-            track: "4.0/edge"
-          - test: lxd-user
-            track: "4.0/edge"
-          - test: network-bridge-firewall
-            track: "4.0/edge"
-            os: 20.04
-          - test: network-ovn ovn:deb
-            track: "4.0/edge"
-          - test: network-ovn ovn:latest/edge
-            track: "4.0/edge"
-          - test: qemu-external-vm
-            track: "4.0/edge"
-          - test: storage-buckets
-            track: "4.0/edge"
-          - test: storage-disks-vm
-            track: "4.0/edge"
-          - test: storage-vm btrfs
-            track: "4.0/edge"
-          - test: storage-vm ceph
-            track: "4.0/edge"
-          - test: storage-vm dir
-            track: "4.0/edge"
-          - test: storage-vm lvm
-            track: "4.0/edge"
-          - test: storage-vm lvm-thin
-            track: "4.0/edge"
-          - test: storage-vm zfs
-            track: "4.0/edge"
-          - test: storage-volumes-vm
-            track: "4.0/edge"
-          - test: tpm-vm
-            track: "4.0/edge"
-          - test: vm-migration
-            track: "4.0/edge"
-          # not compatible with 5.0/*
-          - test: cloud-init
-            track: "5.0/candidate"
-          - test: cloud-init
-            track: "5.0/edge"
-          - test: efi-vars-editor-vm
-            track: "5.0/candidate"
-          - test: efi-vars-editor-vm
-            track: "5.0/edge"
-          - test: network-ovn ovn:latest/edge
-            track: "5.0/candidate"
-          - test: network-ovn ovn:latest/edge
-            track: "5.0/edge"
-          - test: qemu-external-vm
-            track: "5.0/candidate"
-          - test: qemu-external-vm
-            track: "5.0/edge"
-          - test: vm-migration
-            track: "5.0/candidate"
-          - test: vm-migration
-            track: "5.0/edge"
-          # not compatible with 5.21/*
-          - test: qemu-external-vm
-            track: "5.21/candidate"
-          - test: qemu-external-vm
-            track: "5.21/edge"
-          # some tests are not worth testing on specific OSes
-          - os: 20.04
-            test: qemu-external-vm
-          - os: 22.04
-            test: qemu-external-vm
-          # skip track/os combinations that are too far appart
-          - os: 24.04
-            track: "4.0/candidate"
-          - os: 24.04
-            track: "4.0/edge"
-          - os: 24.04
-            track: "5.0/candidate"
-          - os: 24.04
-            track: "5.0/edge"
-          - os: 20.04
-            track: "5.0/candidate"
-          - os: 20.04
-            track: "5.0/edge"
-          - os: 20.04
-            track: "5.21/candidate"
-          - os: 20.04
-            track: "5.21/edge"
-          - os: 20.04
-            track: "latest/candidate"
-          - os: 20.04
             track: "latest/edge"
+            os: 24.04
 
     steps:
       - name: Tune disk performance
@@ -333,7 +193,22 @@ jobs:
               EXTRA_ARGS=""
             fi
           fi
-          sudo --preserve-env=GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,TEST_IMG,OVN_SOURCE ./bin/local-run "tests/${TEST_SCRIPT}" ${{ matrix.track }} ${EXTRA_ARGS:-}
+
+          git clone https://github.com/hamistao/lxd
+          cd lxd
+          git checkout fd_leak_investigation
+          sudo apt update
+          sudo apt install acl attr autoconf automake dnsmasq-base git libacl1-dev libcap-dev liblxc1 liblxc-dev libsqlite3-dev libtool libudev-dev liblz4-dev libuv1-dev make pkg-config rsync squashfs-tools tar tcl xz-utils ebtables
+          command -v snap >/dev/null || sudo apt-get install snapd
+          sudo snap install --classic go
+          make deps
+          export CGO_CFLAGS="-I/home/runner/go/deps/dqlite/include/"
+          export CGO_LDFLAGS="-L/home/runner/go/deps/dqlite/.libs/"
+          export LD_LIBRARY_PATH="/home/runner/go/deps/dqlite/.libs/"
+          export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
+          make
+          cd ..
+          sudo LXD_SIDELOAD_PATH=/home/runner/go/bin/lxd --preserve-env=GITHUB_ACTIONS,GITHUB_STEP_SUMMARY,TEST_IMG,OVN_SOURCE ./bin/local-run "tests/${TEST_SCRIPT}" ${{ matrix.track }} ${EXTRA_ARGS:-}
 
       # always update cache as we have our own logic of
       # cache invalidation and updates in addition to a date check

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -55,7 +55,7 @@ do
 	else
 		lxc storage volume create "${poolName}" vol4 size=8GiB
 	fi
-	lxc storage volume attach "${poolName}" vol4 v1 /foo=
+	lxc storage volume attach "${poolName}" vol4 v1 /foo
 
 	echo "==> Start VM and add content to custom block volume"
 	lxc start v1

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -55,7 +55,7 @@ do
 	else
 		lxc storage volume create "${poolName}" vol4 size=8GiB
 	fi
-	lxc storage volume attach "${poolName}" vol4 v1 /foo
+	lxc storage volume attach "${poolName}" vol4 v1 /foo=
 
 	echo "==> Start VM and add content to custom block volume"
 	lxc start v1


### PR DESCRIPTION
Tests using a `=` in a VM disk device's mount path to check for regressions related to https://github.com/canonical/lxd/pull/14744