### PR TITLE
tests/cgroup: avoid prompts when installing iperf3

### DIFF
--- a/tests/cgroup
+++ b/tests/cgroup
@@ -200,7 +200,7 @@ lxc restart c1 --force
 sleep 10s
 IP=$(lxc network get lxdbr0 ipv4.address | cut -d/ -f1)
 lxc exec c1 -- apt-get update
-lxc exec c1 -- apt-get install --no-install-recommends --yes iperf3
+lxc exec c1 --env DEBIAN_FRONTEND=noninteractive -- apt-get install --no-install-recommends --yes iperf3
 
 iperf3 -s -D
 lxc exec c1 -- iperf3 -c "${IP}" -J > iperf.json


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14772