### PR TITLE
actions/image-upload: Ensure SSH agent is accessible during upload

### DIFF
--- a/.github/actions/image-upload/action.yml
+++ b/.github/actions/image-upload/action.yml
@@ -40,6 +40,7 @@ runs:
         SSH_HOST: images.lxd.canonical.com
         SSH_USER: imageserver
         SSH_PORT: 922
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         # Ensure path of the source directory is expanded.
         SRC_DIR=$(echo ${{ inputs.target }})


### PR DESCRIPTION
Set `SSH_AUTH_SOCK` for the upload step to make SSH agent accessible.

