### PR TITLE
tests/gpu-container: Fix CDI tests with respect to dGPU passthrough and updated LXD validation

### DIFF
--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -118,10 +118,12 @@ lxc exec c1 -- nvidia-smi
 
 # Test with fully-qualified CDI name
 echo "==> Testing adding a GPU with a fully-qualified CDI name"
+lxc config unset c1 nvidia.runtime
+lxc stop --force c1
 lxc config device remove c1 gpus
 lxc config device add c1 gpu0 gpu id="nvidia.com/gpu=0"
-sleep 1
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "${first_card_pci_slot}" ] || false
+lxc start c1
+[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ] || false
 lxc exec c1 -- nvidia-smi
 
 echo "==> Cleaning up"


### PR DESCRIPTION


Validation fixes from https://github.com/canonical/lxd/pull/14535 were not reflected in this test.