### PR TITLE
images/fedora: Add Fedora 41

### DIFF
--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         release:
           - 40
+          - 41
         variant:
           - default
           - cloud

--- a/images/fedora.yaml
+++ b/images/fedora.yaml
@@ -304,6 +304,15 @@ actions:
 - trigger: post-packages
   action: |-
     #!/bin/sh
+    systemctl mask systemd-nsresourced.service systemd-nsresourced.socket
+  types:
+  - container
+  releases:
+  - 41
+
+- trigger: post-packages
+  action: |-
+    #!/bin/sh
     systemctl enable systemd-networkd
   variants:
   - default


### PR DESCRIPTION
Adds Fedora 41 release.

Requires:
- [ ] https://github.com/canonical/lxd-imagebuilder/pull/121

Passing build: https://github.com/MusicDin/lxd-ci/actions/runs/12930858195