### PR TITLE
tests: Address `cloud-init` misconceptions

### DIFF
--- a/tests/devlxd-container
+++ b/tests/devlxd-container
@@ -30,7 +30,8 @@ if hasNeededAPIExtension cloud_init; then
   lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/devices | jq
 fi
 lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/config | jq
-lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id'
+lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id:'
+lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'local-hostname:'
 
 # Restart the container
 lxc restart -f c1
@@ -41,7 +42,8 @@ if hasNeededAPIExtension cloud_init; then
   lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/devices | jq
 fi
 lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/config | jq
-lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id'
+lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id:'
+lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'local-hostname:'
 
 # Disable devlxd
 lxc config set c1 security.devlxd false
@@ -67,7 +69,8 @@ if hasNeededAPIExtension cloud_init; then
   lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/devices | jq
 fi
 lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/config | jq
-lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id'
+lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id:'
+lxc exec c1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'local-hostname:'
 
 if hasNeededAPIExtension instance_ready_state; then
   # test instance Ready state

--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -35,7 +35,8 @@ echo "==> Checking devlxd is working"
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0 | jq
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/devices | jq
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/config | jq
-lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id'
+lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id:'
+lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'local-hostname:'
 
 # Run sync before forcefully restarting the VM otherwise the filesystem will be corrupted.
 lxc exec v1 -- "sync"
@@ -46,7 +47,8 @@ waitInstanceReady v1
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0 | jq
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/devices | jq
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/config | jq
-lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id'
+lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id:'
+lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'local-hostname:'
 
 # Disable devlxd
 lxc config set v1 security.devlxd false
@@ -71,7 +73,8 @@ lxc config set v1 security.devlxd true
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0 | jq
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/devices | jq
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/config | jq
-lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id'
+lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id:'
+lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'local-hostname:'
 
 if hasNeededAPIExtension instance_ready_state; then
   # test instance Ready state


### PR DESCRIPTION
This adapts the CI to the changes introduced on https://github.com/canonical/lxd/pull/14852.