### PR TITLE
Fix check for PowerFlex volume size

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ To run the VM storage tests on the Dell PowerFlex driver, provide the following 
 * `POWERFLEX_PASSWORD`: Password of the PowerFlex user
 * `POWERFLEX_MODE`: Operation mode for the consumption of storage volumes. The default is `nvme`.
 
+Ideally use a PowerFlex storage pool (`POWERFLEX_POOL`) which has zero-padding disabled so that the PowerFlex storage driver has to
+clear the blocks beforehand.
+
 # Infrastructure managed by IS
 
 The PS6 environment has inbound and outbound firewalling applied at the network edge. In order to access some external sites here are the firewall rules we added to firewall maintained by IS:

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -595,8 +595,9 @@ for poolDriver in $poolDriverList; do
                 echo "==> Checking new VM root disk size has default volume size of 10GiB"
                 [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "10" ]
         else
-                echo "==> Checking new VM root disk size has default volume size of 16GiB"
-                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "16" ]
+                echo "==> Checking new VM root disk size has default volume size of 24GiB"
+                # 24GiB was the size of the VM's root volume when publishing the image.
+                [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "24" ]
         fi
 
         echo "===> Renaming VM"


### PR DESCRIPTION
Observed whilst running the tests for https://github.com/canonical/lxd/pull/14865.

Also added a note to run more robust PowerFlex tests that cope with zero-padding disabled.