### PR TITLE
bin/helpers: refresh snapd only after (old) snapd is seeded

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -235,12 +235,15 @@ configure_ovn() {
 install_lxd() (
     local start_daemon="${1:-true}"
 
-    # Ensure latest snapd in case LXD requires a newer one than is installed.
-    apt-get update --yes
-    apt-get upgrade snapd --yes
-
     # Wait for snapd seeding
     waitSnapdSeed
+
+    # Ensure latest snapd in case LXD requires a newer one than is installed.
+    if snap list snapd 2> /dev/null; then
+        snap refresh snapd --cohort="+" || true
+    else
+        snap install snapd --cohort="+" || true
+    fi
 
     if [ -n "${KEEP_LXD:-}" ]; then
         # Make sure LXD is started at least


### PR DESCRIPTION
The `apt-get` way worked but caused every pending update to be applied, not just snapd's because `apt-get upgrade` ignore package selection:

```
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages have been kept back:
  dotnet-runtime-6.0 linux-azure linux-cloud-tools-azure linux-headers-azure
  linux-image-azure linux-tools-azure sosreport
The following packages will be upgraded:
  apache2 apache2-bin apache2-data apache2-utils aspnetcore-runtime-6.0
  aspnetcore-targeting-pack-6.0 bind9-dnsutils bind9-host bind9-libs
  cloud-init distro-info-data dmidecode dotnet-apphost-pack-6.0
  dotnet-hostfxr-6.0 dotnet-targeting-pack-6.0 firefox
  gir1.2-packagekitglib-1.0 libarchive13 libcurl3-gnutls libglib2.0-data
  libgstreamer1.0-0 libmbim-glib4 libmbim-proxy libopenjp2-7 libopenjp2-7-dev
  libpackagekit-glib2-18 libpam-modules libpam-modules-bin libpam-runtime
  libpam0g linux-cloud-tools-common linux-libc-dev linux-tools-common nano
  netstandard-targeting-pack-2.1 packagekit packagekit-tools powershell
  python3-configobj python3-urllib3 snapd vim vim-common vim-runtime vim-tiny
  xfsprogs xxd
```

The `snapd` refresh itself was suddenly needed because now LXD requires 2.64+ and ATM, `-security` only has 2.63:

```
$ rmadison snapd
 snapd | 2.0.2               | xenial           | source, amd64, arm64, armhf, i386, powerpc, ppc64el, s390x
 snapd | 2.32.5+18.04        | bionic           | source, amd64, arm64, armhf, i386, ppc64el, s390x
 snapd | 2.37.4~14.04.1      | trusty-security  | source, amd64, armhf, i386
 snapd | 2.38~14.04          | trusty-updates   | source, amd64, armhf, i386
 snapd | 2.44.3+20.04        | focal            | source, amd64, arm64, armhf, ppc64el, s390x
 snapd | 2.48.3              | xenial-security  | source, amd64, arm64, armhf, i386, powerpc, ppc64el, s390x
 snapd | 2.48.3              | xenial-updates   | source, amd64, arm64, armhf, i386, powerpc, ppc64el, s390x
 snapd | 2.55.3+22.04        | jammy            | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 snapd | 2.58+18.04.1        | bionic-security  | source, amd64, arm64, armhf, i386, ppc64el, s390x
 snapd | 2.58+18.04.1        | bionic-updates   | source, amd64, arm64, armhf, i386, ppc64el, s390x
 snapd | 2.62+24.04build1    | noble            | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 snapd | 2.63+20.04ubuntu0.1 | focal-security   | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 snapd | 2.63+22.04ubuntu0.1 | jammy-security   | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 snapd | 2.63+24.04ubuntu0.1 | noble-security   | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 snapd | 2.65.3+24.10        | oracular         | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 snapd | 2.66.1+20.04        | focal-updates    | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 snapd | 2.66.1+22.04        | jammy-updates    | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 snapd | 2.66.1+24.04        | noble-updates    | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 snapd | 2.66.1+24.10        | oracular-updates | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
 snapd | 2.66.1+25.04        | plucky           | source, amd64, arm64, armhf, ppc64el, riscv64, s390x
```

Refreshing snapd's snap will have the advantage of getting us version 2.67 instead of 2.66.1 (from `-updates`):

```
$ snap list snapd
Name   Version  Rev    Tracking       Publisher   Notes
snapd  2.67     23545  latest/stable  canonical✓  snapd
```