### PR TITLE
bin/helpers: use proper channel when installing LXD from custom snap

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -252,7 +252,7 @@ install_lxd() (
         # snapstore then install with --dangerous. The alias needs to be created
         # manually too.
         if [ -n "${LXD_SNAP_PATH:-}" ]; then
-            snap list lxd 2>/dev/null || snap install lxd
+            snap list lxd 2>/dev/null || snap install lxd --channel "${LXD_SNAP_CHANNEL}" --cohort=+
             snap install --dangerous "${LXD_SNAP_PATH}"
             snap alias lxd.lxc lxc
         else


### PR DESCRIPTION
Before, doing `snap install lxd` would pull LXD `5.21/stable` which is ATM based on `core22` but chances are that the custom LXD snap provided is a modern one based on `core24`. As such, you end up pulling `core22` just for getting your custom snap installable.

Instead, pull the official LXD snap from the requested channel which still works to give us the assert required to then be able to install custom LXD snap. This way, a virgin VM won't need to uselessly download `core22`.