### PR TITLE
tests/network: Add tests for `agent.nic_config` on VMs with physical NIC

### DIFF
--- a/tests/network
+++ b/tests/network
@@ -150,6 +150,25 @@ networkTests
 lxc exec v1-macvlan -- apt-get install --no-install-recommends --yes ethtool
 lxc exec v1-macvlan -- ethtool -l enp5s0 | grep -c '^Combined:\s\+3$'  | grep -Fx 2
 
+# Check VM "agent.nic_config" works by reconfiguring eth0 to use parent and mtu settings.
+echo "=> Performing VM physical NIC agent.nic_config tests"
+lxc exec v1-physical -- "sync"
+lxc stop v1-physical -f
+lxc config set v1-physical agent.nic_config=true
+lxc config device set v1-physical eth0 nictype=physical parent="${parentNIC}v1" mtu=1400 name=eth0
+lxc start v1-physical
+
+# Wait for lxd-agent to rename the interface.
+waitInstanceBooted v1-physical
+
+# Get the MAC address of the host NIC.
+parentNICMAC=$(cat /sys/class/net/"${parentNIC}v1"/address)
+
+# Interface "eth0" should exist in the VM with the correct MTU and MAC address.
+lxc exec v1-physical -- test -d /sys/class/net/eth0
+lxc exec v1-physical -- grep -Fx 1400 /sys/class/net/eth0/mtu
+lxc exec v1-physical -- cat /sys/class/net/eth0/address | grep -Fx "${parentNICMAC}"
+
 # Hot unplug the NICs and check they are removed
 lxc config device remove v1-physical eth0
 ! lxc exec v1-physical -- ip a show enp5s0 || false


### PR DESCRIPTION
Tests related to https://github.com/canonical/lxd/pull/14905.

This PR add tests for physical NICs, confirming that `agent.nic_config` works as expected by checking the MTU and MAC address of a parent NIC added to a virtual machine.