### PR TITLE
OpenWrt 24.10

### DIFF
--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -52,7 +52,7 @@ jobs:
           [ "${ARCH}" = "arm64" ] && IMAGE_ARCH="aarch64"
 
           EXTRA_ARGS=""
-          if [ "${{ matrix.release }}" = "23.05" ]; then
+          if [ "${{ matrix.release }}" != "snapshot" ]; then
               EXTRA_ARGS="-o packages.manager=opkg"
           fi
 

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         release:
           - snapshot
+          - 24.10
           - 23.05
         variant:
           - default


### PR DESCRIPTION
https://openwrt.org/releases/24.10/notes-24.10.0:
> OpenWrt 24.10.0 - First Stable Release - 6. February 2025