### PR TITLE
openwrt: Quote release ending with 0

### DIFF
--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         release:
           - snapshot
-          - 24.10
+          - "24.10"
           - 23.05
         variant:
           - default


### PR DESCRIPTION
GitHub cuts `0` at the end resolving `24.10` into `24.1`.

This can be observed in this action run: https://github.com/canonical/lxd-ci/actions/runs/13203486797

Here is the passing build with quotes: https://github.com/MusicDin/lxd-ci/actions/runs/13204108061/job/36863042112

