### PR TITLE
actions/image-setup: Install umoci for modifying OCI

### DIFF
--- a/.github/actions/image-setup/action.yml
+++ b/.github/actions/image-setup/action.yml
@@ -29,7 +29,8 @@ runs:
             make \
             qemu-utils \
             rsync \
-            squashfs-tools
+            squashfs-tools \
+            umoci
 
     - name: Setup LXD Imagebuilder ${{ inputs.lxd-imagebuilder-channel }}
       shell: bash


### PR DESCRIPTION
Installs `umoci` (https://github.com/opencontainers/umoci) that is required for modifying open container images.