### PR TITLE
tests: Add tests for the NoCloud datasource

### DIFF
--- a/tests/cloud-init
+++ b/tests/cloud-init
@@ -56,5 +56,22 @@ rm ./profile-key ./profile-key.pub ./additional-key ./additional-key.pub
 lxc profile unset default cloud-init.user-data
 lxc delete -f c1
 
+echo "==> Use the NoCloud datasource by using a disk device with a \"cloud-init:config\" source"
+lxc init ubuntu:n vm1 --vm -c user.user=user -c cloud-init.user-data="$(cat <<EOF
+#cloud-config
+users:
+  - name: "{{ ds.meta_data.user_user }}"
+EOF
+)"
+lxc config device add vm1 config disk source=cloud-init:config
+lxc start vm1
+waitInstanceBooted c1
+lxc exec vm1 -- cloud-init status --wait --long | grep "detail: DataSourceNoCloud"
+lxc exec vm1 -- grep -E 'user' /etc/shadow
+! lxc exec vm1 -- grep -E 'ubuntu' /etc/shadow || false
+
+# Cleanup
+lxc delete -f vm1
+
 # shellcheck disable=SC2034
 FAIL=0


### PR DESCRIPTION
This assumes https://github.com/canonical/lxd/pull/14983 will be merged and backported to LXD versions that contain the `cloud-init` extension