### PR TITLE
Tests: Don't set storage.images_volume for Ceph RBD

### DIFF
--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -628,16 +628,25 @@ for poolDriver in $poolDriverList; do
 
         echo "==> Publishing VM to image"
         lxc init "${IMAGE}" v1 --vm -s "${poolName}"
-        lxc storage volume create "${poolName}" images
-        lxc config set storage.images_volume "${poolName}"/images
+
+        # Set the images_volume on supported drivers only.
+        # Ceph RBD is not supported because it's volumes don't allow concurrent read/writes from multiple hosts.
+        if [ "${poolDriver}" != "ceph" ]; then
+                lxc storage volume create "${poolName}" images
+                lxc config set storage.images_volume "${poolName}"/images
+        fi
+
         lxc publish v1 --alias v1image
         lxc delete v1
         lxc launch v1image v2 -s "${poolName}" # --vm flag omitted as we are implicitly launching a vm
         waitInstanceReady v2
         lxc delete -f v2
         lxc image delete v1image
-        lxc config unset storage.images_volume
-        lxc storage volume delete "${poolName}" images
+
+        if [ "${poolDriver}" != "ceph" ]; then
+                lxc config unset storage.images_volume
+                lxc storage volume delete "${poolName}" images
+        fi
 
         if hasNeededAPIExtension instances_migration_stateful; then
                 echo "==> Checking setting instances.migration.stateful for VMs"


### PR DESCRIPTION
After landing https://github.com/canonical/lxd/pull/14993 the `storage-vm` test should only set the `storage.images_volume` config key for supported storage drivers.

Ceph RBD is not supported because it's volumes don't allow concurrent read/writes from multiple hosts.