### PR TITLE
tests/container: wait for snapd init before installing LXD snap

### DIFF
--- a/tests/container
+++ b/tests/container
@@ -143,7 +143,11 @@ for release in $RELEASES; do
 
     echo "==> nested container (${release})"
     lxc launch "${IMAGE}" n1 -c security.nesting=true -c security.devlxd.images=true
+    lxc exec n1 -- snap list || true
     isSystemdClean n1 || ignore_known_issues "n1" "nesting"
+    lxc exec n1 -- sh -c "$(declare -f waitSnapdSeed); waitSnapdSeed"
+    lxc exec n1 -- snap list || true
+    sleep 5
     lxc exec n1 -- snap install lxd --channel="${LXD_SNAP_CHANNEL}"
     lxc exec n1 -- lxd init --auto
     lxc exec n1 -- lxc launch "${IMAGE}" n11


### PR DESCRIPTION
It is an attempt to fix failures like this:
```
+ echo '==> nested container (22.04)'

+ lxc launch ubuntu-minimal-daily:22.04 n1 -c security.nesting=true -c security.devlxd.images=true ==> nested container (22.04)
Launching n1

Retrieving image: Unpacking image: 100% (1.25GB/s)

Retrieving image: Unpacking image: 100% (1.25GB/s)
+ isSystemdClean n1
+ lxc exec n1 -- snap install lxd --channel=latest/edge error: cannot install "lxd": Post "https://api.snapcraft.io/v2/snaps/refresh":
       context canceled
+ cleanup
```