### PR TITLE
tests: Add jinja template tag on user data

### DIFF
--- a/tests/cloud-init
+++ b/tests/cloud-init
@@ -58,6 +58,7 @@ fi
 # Cleanup
 rm ./profile-key ./profile-key.pub ./additional-key ./additional-key.pub
 lxc profile unset default cloud-init.user-data
+lxc profile unset default cloud-init.ssh-keys.ignored
 lxc delete -f c1
 
 echo "==> Use the NoCloud datasource by using a disk device with a \"cloud-init:config\" source"

--- a/tests/cloud-init
+++ b/tests/cloud-init
@@ -66,7 +66,7 @@ lxc init "${IMAGE}" v1 --vm -c cloud-init.user-data="$(cat <<EOF
 ## template: jinja
 #cloud-config
 users:
-  - name: "{{ ds.meta_data.user_user }}"
+  - name: {{ ds.meta_data.user_user }}
 EOF
 )"
 

--- a/tests/cloud-init
+++ b/tests/cloud-init
@@ -14,7 +14,7 @@ fi
 # Configure LXD
 lxd init --auto
 
-IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"
+IMAGE="${TEST_IMG:-ubuntu-daily:24.04}" # Avoid running into this bug: https://github.com/canonical/lxd/issues/14605
 
 echo "==> Create key pairs for tests"
 ssh-keygen -t ed25519 -f "./profile-key" -N ""

--- a/tests/cloud-init
+++ b/tests/cloud-init
@@ -62,6 +62,7 @@ lxc delete -f c1
 
 echo "==> Use the NoCloud datasource by using a disk device with a \"cloud-init:config\" source"
 lxc init "${IMAGE}" v1 --vm -c cloud-init.user-data="$(cat <<EOF
+## template: jinja
 #cloud-config
 users:
   - name: "{{ ds.meta_data.user_user }}"


### PR DESCRIPTION
This prevents failures such as https://github.com/canonical/lxd-ci/actions/runs/14237699920/job/39900238626 and includes other small fixes and improvements.