### PR TITLE
Be smarter when installing dependencies

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -127,8 +127,12 @@ install_deps() (
         # Many commands are already available on CI runners (like `jq` and
         # `yq`) and are sometimes not installed using deb packages (like `yq`).
         # As such check if a binary of the same name as the package needing to
-        # be installed is present
-        command -v "${pkg}" > /dev/null && continue
+        # be installed is present.
+        # XXX: iptables, nftables and ebtables need special handling due to
+        #      using alternative mechanism
+        if ! [[ "${pkg}" =~ .*tables ]]; then
+            command -v "${pkg}" > /dev/null && continue
+        fi
 
         grep -qxF "${pkg}" <<< "${PKGS_LIST}" && continue
         missing="${missing} ${pkg}"

--- a/bin/helpers
+++ b/bin/helpers
@@ -124,6 +124,12 @@ install_deps() (
     missing=""
     PKGS_LIST="$(dpkg --get-selections | awk '{print $1}')"
     for pkg in ${PKGS}; do
+        # Many commands are already available on CI runners (like `jq` and
+        # `yq`) and are sometimes not installed using deb packages (like `yq`).
+        # As such check if a binary of the same name as the package needing to
+        # be installed is present
+        command -v "${pkg}" > /dev/null && continue
+
         grep -qxF "${pkg}" <<< "${PKGS_LIST}" && continue
         missing="${missing} ${pkg}"
         break

--- a/tests/storage-metadata
+++ b/tests/storage-metadata
@@ -65,8 +65,10 @@ if dpkg --compare-versions "${VERSION_ID}" ge 24.04; then
     install_deps jq yq
 else
     install_deps jq
-    waitSnapdSeed
-    snap install yq
+    if ! command -v yq > /dev/null; then
+        waitSnapdSeed
+        snap install yq
+    fi
 fi
 
 # Install LXD.


### PR DESCRIPTION
GH CI runners come with `yq` already installed, see [`ubuntu-22.04`](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) and [`ubuntu-24.04`](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).

Yet, https://github.com/canonical/lxd-ci/actions/runs/14658595375/job/41138030832 shows that `yq` is installed:
```
 Building dependency tree...
Reading state information...
jq is already the newest version (1.7.1-3build1).
The following additional packages will be installed:
  python3-argcomplete python3-toml python3-xmltodict
The following NEW packages will be installed:
  python3-argcomplete python3-toml python3-xmltodict yq
0 upgraded, 4 newly installed, 0 to remove and 25 not upgraded.
Need to get 80.6 kB of archives.
After this operation, 351 kB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 python3-argcomplete all 3.1.4-1ubuntu0.1 [33.8 kB]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 python3-toml all 0.10.2-1 [16.5 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 python3-xmltodict all 0.13.0-1 [13.4 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 yq all 3.1.0-3 [16.9 kB]
```

Fortunately, `jq` was already available in the runner and was installed via a deb package so it was not installed again.