### PR TITLE
tests/cluster: wait for LXD to be ready on all members

### DIFF
--- a/tests/cluster
+++ b/tests/cluster
@@ -35,7 +35,9 @@ instance_connectivity_checks() {
 
 wait_for_online_cluster() {
     sleep 5
-    lxc exec m1 -- lxd waitready --timeout=300
+    for i in $(seq "${SIZE}"); do
+        lxc exec "m${i}" -- lxd waitready --timeout=300
+    done
     for _ in $(seq 30); do
         ONLINE_MEMBERS="$(lxc exec m1 -- lxc cluster list | grep -cwF ONLINE || true)"
         [ "${ONLINE_MEMBERS}" = "${SIZE}" ] && break


### PR DESCRIPTION
During cluster upgrades, LXD is asked for be refreshed but only on a single cluster member (the last one (`m3`)) and the other members are notified by LXD to do the same on their own.

When `m3` triggered the refresh cascade, the `wait_for_online_cluster` helper immediately kicked in and `m1` saw the 3 members as online:

```
Fri, 25 Apr 2025 19:50:31 GMT + lxc exec m3 -- timeout 10m snap refresh lxd
Fri, 25 Apr 2025 19:50:37 GMT 2025-04-25T19:50:37Z INFO Waiting for "snap.lxd.daemon.service" to stop.
Fri, 25 Apr 2025 19:51:20 GMT lxd (5.21/edge) git-d6307d1 from Canonical** refreshed
Fri, 25 Apr 2025 19:51:20 GMT + echo '==> Wait for all members to be ONLINE'
Fri, 25 Apr 2025 19:51:20 GMT ==> Wait for all members to be ONLINE
Fri, 25 Apr 2025 19:51:20 GMT + wait_for_online_cluster
Fri, 25 Apr 2025 19:51:20 GMT + sleep 5
Fri, 25 Apr 2025 19:51:25 GMT + lxc exec m1 -- lxd waitready --timeout=300
Fri, 25 Apr 2025 19:51:28 GMT ++ seq 30
Fri, 25 Apr 2025 19:51:28 GMT + for _ in $(seq 30)
Fri, 25 Apr 2025 19:51:28 GMT ++ lxc exec m1 -- lxc cluster list
Fri, 25 Apr 2025 19:51:28 GMT ++ grep -cwF ONLINE
Fri, 25 Apr 2025 19:51:28 GMT + ONLINE_MEMBERS=3
Fri, 25 Apr 2025 19:51:28 GMT + '[' 3 = 3 ']'
Fri, 25 Apr 2025 19:51:28 GMT + break
Fri, 25 Apr 2025 19:51:28 GMT + sleep 5
Fri, 25 Apr 2025 19:51:33 GMT + echo '==> Validating the cluster'
```

However, it is possible that all 3 members had their LXD restarting due to the snap refresh. This is what the `lxc cluster list` hints at:

````
Fri, 25 Apr 2025 19:51:33 GMT + lxc exec m1 -- lxc cluster list
Fri, 25 Apr 2025 19:51:34 GMT +------+----------------------------+-----------------+--------------+----------------+-------------+---------+--------------------------------------------------------------------------+
Fri, 25 Apr 2025 19:51:34 GMT | NAME |            URL             |      ROLES      | ARCHITECTURE | FAILURE DOMAIN | DESCRIPTION |  STATE  |                                 MESSAGE                                  |
Fri, 25 Apr 2025 19:51:34 GMT +------+----------------------------+-----------------+--------------+----------------+-------------+---------+--------------------------------------------------------------------------+
Fri, 25 Apr 2025 19:51:34 GMT | m1   | https://10.41.199.215:8443 | database-leader | x86_64       | default        |             | ONLINE  | Fully operational                                                        |
Fri, 25 Apr 2025 19:51:34 GMT |      |                            | database        |              |                |             |         |                                                                          |
Fri, 25 Apr 2025 19:51:34 GMT +------+----------------------------+-----------------+--------------+----------------+-------------+---------+--------------------------------------------------------------------------+
Fri, 25 Apr 2025 19:51:34 GMT | m2   | https://10.41.199.194:8443 | database        | x86_64       | default        |             | OFFLINE | No heartbeat for 23.916551542s (2025-04-25 19:51:10.1865944 +0000 UTC)   |
Fri, 25 Apr 2025 19:51:34 GMT +------+----------------------------+-----------------+--------------+----------------+-------------+---------+--------------------------------------------------------------------------+
Fri, 25 Apr 2025 19:51:34 GMT | m3   | https://10.41.199.102:8443 | database        | x86_64       | default        |             | OFFLINE | No heartbeat for 21.281126043s (2025-04-25 19:51:12.822029477 +0000 UTC) |
Fri, 25 Apr 2025 19:51:34 GMT +------+----------------------------+-----------------+--------------+----------------+-------------+---------+--------------------------------------------------------------------------+
Fri, 25 Apr 2025 19:51:34 GMT + echo '==> Verify that instances are still functional after the cluster upgrade'
Fri, 25 Apr 2025 19:51:34 GMT ==> Verify that instances are still functional after the cluster upgrade
Fri, 25 Apr 2025 19:51:34 GMT + instance_connectivity_checks
Fri, 25 Apr 2025 19:51:34 GMT ++ lxc exec m1 -- lxc list u2 -c4 --format=csv
Fri, 25 Apr 2025 19:51:34 GMT ++ cut '-d ' -f1
Fri, 25 Apr 2025 19:51:34 GMT + U2_IPV4=
Fri, 25 Apr 2025 19:51:34 GMT + lxc exec m1 -- lxc exec u1 -- timeout 30s bash -c 'grep -m1 ^SSH < /dev/tcp//22'
Fri, 25 Apr 2025 19:51:34 GMT bash: line 1: : Name or service not known
Fri, 25 Apr 2025 19:51:34 GMT bash: line 1: /dev/tcp//22: Invalid argument
Fri, 25 Apr 2025 19:51:34 GMT + cleanup
```

To close that race, `wait_for_online_cluster` will make sure all LXDs are ready before counting online members.