### PR TITLE
images/opensuse: Fix missing dracut package and sddm on desktop variant

### DIFF
--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -244,6 +244,7 @@ packages:
 
   - packages:
     - hardlink
+    - dracut
     action: install
     releases:
     - tumbleweed

--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -340,7 +340,7 @@ actions:
 
     sed -ri "s#(DISPLAYMANAGER_AUTOLOGIN)=.*#\1=${USERNAME}#" /etc/sysconfig/displaymanager
 
-    systemctl enable sddm
+    systemctl enable sddm || true
 
     # When calling `lxc stop` KDE will show a dialog for 30 seconds which defaults to logging out.
     # This decreases the timeout to 10 seconds, and performs a shutdown per default.

--- a/images/opensuse.yaml
+++ b/images/opensuse.yaml
@@ -245,6 +245,7 @@ packages:
   - packages:
     - hardlink
     - dracut
+    - net-tools
     action: install
     releases:
     - tumbleweed
@@ -262,12 +263,6 @@ packages:
     - aarch64
     - x86_64
     - i686
-
-  - packages:
-    - net-tools
-    releases:
-    - tumbleweed
-    action: install
 
   - packages:
     - cloud-init


### PR DESCRIPTION
Fixes:
- Install dracut for thumbleweed images
- Fix sddm for desktop images
