### PR TITLE
tests/network-bridge-firewall: defensive check for br_netfilter presence

### DIFF
--- a/tests/network-bridge-firewall
+++ b/tests/network-bridge-firewall
@@ -45,7 +45,9 @@ ebtables --version 2>&1 | grep legacy
 
 # Check if br_netfilter module is already loaded.
 BR_NETFILTER_LOADED=false
-lsmod | grep -qw ^br_netfilter && BR_NETFILTER_LOADED=true
+if lsmod | grep -qw ^br_netfilter; then
+    BR_NETFILTER_LOADED=true
+fi
 
 # Setup bridge filter and unmanaged bridges
 modprobe br_netfilter


### PR DESCRIPTION
This is not strictly needed as the test scripts are not ran with `-o pipefail` so shouldn't fail even if `grep` doesn't find any match. Doing this now will make it simpler to use `-o pipefail` later on if we ever want.