### PR TITLE
github: don't build/publish images during the weekends

### DIFF
--- a/.github/workflows/image-almalinux.yml
+++ b/.github/workflows/image-almalinux.yml
@@ -2,7 +2,7 @@ name: AlmaLinux
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -2,7 +2,7 @@ name: Alpine
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -2,7 +2,7 @@ name: ALT Linux
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-amazonlinux.yml
+++ b/.github/workflows/image-amazonlinux.yml
@@ -2,7 +2,7 @@ name: AmazonLinux
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-archlinux.yml
+++ b/.github/workflows/image-archlinux.yml
@@ -2,7 +2,7 @@ name: ArchLinux
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-busybox.yml
+++ b/.github/workflows/image-busybox.yml
@@ -2,7 +2,7 @@ name: BusyBox
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -2,7 +2,7 @@ name: CentOS
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -2,7 +2,7 @@ name: Debian
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -2,7 +2,7 @@ name: Devuan
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -2,7 +2,7 @@ name: Fedora
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-funtoo.yml
+++ b/.github/workflows/image-funtoo.yml
@@ -2,7 +2,7 @@ name: Funtoo
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -2,7 +2,7 @@ name: Gentoo
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-kali.yml
+++ b/.github/workflows/image-kali.yml
@@ -2,7 +2,7 @@ name: Kali
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -2,7 +2,7 @@ name: Linux Mint
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-nixos.yml
+++ b/.github/workflows/image-nixos.yml
@@ -2,7 +2,7 @@ name: NixOS
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -2,7 +2,7 @@ name: openEuler
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -2,7 +2,7 @@ name: OpenSUSE
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -2,7 +2,7 @@ name: OpenWrt
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -2,7 +2,7 @@ name: Oracle
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-rockylinux.yml
+++ b/.github/workflows/image-rockylinux.yml
@@ -2,7 +2,7 @@ name: RockyLinux
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -2,7 +2,7 @@ name: Slackware
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -2,7 +2,7 @@ name: Ubuntu
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-voidlinux.yml
+++ b/.github/workflows/image-voidlinux.yml
@@ -2,7 +2,7 @@ name: VoidLinux
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Build amd64 (Daily at 00:00 UTC).
+    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
     - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Most distributions do not publish images during the weekends for obvious reasons so rebuilding/republishing those works against the local cache that LXD manages.

Closes https://github.com/canonical/lxd/issues/13294