### PR TITLE
github/testflinger: use stable channel for pc-kernel snap

### DIFF
--- a/.github/workflows/testflinger/uc-nvidia-job.yml
+++ b/.github/workflows/testflinger/uc-nvidia-job.yml
@@ -36,7 +36,7 @@ test_data:
     wait_for_snap_changes
 
     # refresh to the new kernel
-    _run sudo snap refresh pc-kernel --channel 24/edge/nvidia-components-dev --no-wait
+    _run sudo snap refresh pc-kernel --channel 24/stable --no-wait
     wait_for_snap_changes
 
     # install the module component


### PR DESCRIPTION
Now we can (and should) use 24/stable channel for pc-kernel snap instead of temporary and expired 24/edge/nvidia-components-dev.

Tested with:
JOB_QUEUE=lxd-nvidia SNAP_CHANNEL=latest/edge DISTRO=core24-latest ./run.sh

from local machine.