### PR TITLE
github: use a US mirror to download openEuler

### DIFF
--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -57,7 +57,7 @@ jobs:
               -o image.architecture="${IMAGE_ARCH}" \
               -o image.release=${{ matrix.release }} \
               -o image.variant=${{ matrix.variant }} \
-              -o source.url=https://mirror.accum.se/mirror/openeuler.org
+              -o source.url=https://mirrors.ocf.berkeley.edu/openeuler
 
       - name: Print build artifacts
         run: ls -lah "${{ env.target }}"


### PR DESCRIPTION
Our CI runners building images are also located in the US.