### PR TITLE
images/oracle: Remove `security.selinux` xattr on Oracle 9 images

### DIFF
--- a/images/oracle.yaml
+++ b/images/oracle.yaml
@@ -185,6 +185,14 @@ actions:
     # Disable loginuid in PAM stack
     sed -i '/^session.*pam_loginuid.so/s/^session/# session/' /etc/pam.d/*
 
+# Remove security.selinux xattr on container images.
+- trigger: post-unpack
+  action: |-
+    #!/bin/sh
+    find / -xdev -exec setfattr -x security.selinux {} 2>/dev/null \;
+  types:
+  - container
+
 # Strip security.ima from all files that have it set.
 - trigger: post-files
   action: |-


### PR DESCRIPTION
Remove `security.selinux` xattr on container images. Similar to previously applied fix on CentOS 9-Stream images (see https://github.com/canonical/lxd-ci/pull/285).

Passing build on fork: https://github.com/MusicDin/lxd-ci/actions/runs/15270337375