### PR TITLE
tests/storage-metadata: ask `tar` to stop scanning the archive when the needed file is found

### DIFF
--- a/tests/storage-metadata
+++ b/tests/storage-metadata
@@ -152,7 +152,7 @@ EOF
         # 5.0/5.21 always use the old format.
         # > 5.21 uses the new format.
         lxc export c1:i1 "${tmpdir}/i1.tar.gz"
-        tar -xzf "${tmpdir}/i1.tar.gz" -C "${tmpdir}" backup/index.yaml
+        tar --occurrence=1 -xzf "${tmpdir}/i1.tar.gz" -C "${tmpdir}" backup/index.yaml
 
         echo "==> Check the backup index file"
         cat "${tmpdir}/backup/index.yaml"
@@ -188,7 +188,7 @@ EOF
         if lxc exec c1 -- sh -c "$(declare -f hasNeededAPIExtension); hasNeededAPIExtension backup_metadata_version" && hasNeededAPIExtension backup_metadata_version; then
             echo "==> Export using the old backup format 1 explicitly"
             lxc export c1:i1 "${tmpdir}/i1.tar.gz" --export-version 1
-            tar -xzf "${tmpdir}/i1.tar.gz" -C "${tmpdir}" backup/index.yaml
+            tar --occurrence=1 -xzf "${tmpdir}/i1.tar.gz" -C "${tmpdir}" backup/index.yaml
 
             echo "==> Check the backup index file"
             cat "${tmpdir}/backup/index.yaml"
@@ -205,7 +205,7 @@ EOF
 
             echo "==> Export using the new backup format 2 explicitly"
             lxc export c1:i1 "${tmpdir}/i1.tar.gz" --export-version 2
-            tar -xzf "${tmpdir}/i1.tar.gz" -C "${tmpdir}" backup/index.yaml
+            tar --occurrence=1 -xzf "${tmpdir}/i1.tar.gz" -C "${tmpdir}" backup/index.yaml
 
             echo "==> Check the backup index file"
             cat "${tmpdir}/backup/index.yaml"
@@ -245,7 +245,7 @@ EOF
     # 5.0/5.21 always use the old format.
     # > 5.21 uses the new format.
     lxc storage volume export c1:default foo "${tmpdir}/foo.tar.gz"
-    tar -xzf "${tmpdir}/foo.tar.gz" -C "${tmpdir}" backup/index.yaml
+    tar --occurrence=1 -xzf "${tmpdir}/foo.tar.gz" -C "${tmpdir}" backup/index.yaml
 
     echo "==> Check the backup index file"
     cat "${tmpdir}/backup/index.yaml"
@@ -281,7 +281,7 @@ EOF
     if lxc exec c1 -- sh -c "$(declare -f hasNeededAPIExtension); hasNeededAPIExtension backup_metadata_version" && hasNeededAPIExtension backup_metadata_version; then
         echo "==> Export using the old backup format 1 explicitly"
         lxc storage volume export c1:default foo "${tmpdir}/foo.tar.gz" --export-version 1
-        tar -xzf "${tmpdir}/foo.tar.gz" -C "${tmpdir}" backup/index.yaml
+        tar --occurrence=1 -xzf "${tmpdir}/foo.tar.gz" -C "${tmpdir}" backup/index.yaml
 
         echo "==> Check the backup index file"
         cat "${tmpdir}/backup/index.yaml"
@@ -298,7 +298,7 @@ EOF
 
         echo "==> Export using the new backup format 2 explicitly"
         lxc storage volume export c1:default foo "${tmpdir}/foo.tar.gz" --export-version 2
-        tar -xzf "${tmpdir}/foo.tar.gz" -C "${tmpdir}" backup/index.yaml
+        tar --occurrence=1 -xzf "${tmpdir}/foo.tar.gz" -C "${tmpdir}" backup/index.yaml
 
         echo "==> Check the backup index file"
         cat "${tmpdir}/backup/index.yaml"


### PR DESCRIPTION
Since `backup/index.yaml` is at the begining of the archive:

```
$ tar -tzf v1.tar.gz
backup/index.yaml
backup/virtual-machine
backup/virtual-machine/backup.yaml
backup/virtual-machine/metadata.yaml
backup/virtual-machine/templates
backup/virtual-machine/templates/hostname.tpl
backup/virtual-machine.img
```

This should save some time reading/decompressing:

```
$ time tar -tzf v1.tar.gz backup/index.yaml
backup/index.yaml

real	0m15.132s
user	0m14.430s
sys	0m1.913s

$ time tar --occurrence=1 -tzf v1.tar.gz backup/index.yaml
backup/index.yaml

real	0m0.004s
user	0m0.001s
sys	0m0.003s
```