### PR TITLE
github: Allow more time for Mint images to build

### DIFF
--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build image
         run: |
-          TIMEOUT=1800
+          TIMEOUT=3600
           YAML="images/${{ env.distro }}.yaml"
           ARCH="${{ matrix.architecture }}"
           TYPE="${{ env.type }}"


### PR DESCRIPTION
Mint uses Ubuntu archives which have had a rough few days where they are so slow that they cause repeated timeouts.