### PR TITLE
github: remove Ubuntu Focal (20.04) that is now EOL

### DIFF
--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - jammy
-          - noble
+          - jammy  # EOL: 2027-04
+          - noble  # EOL: 2029-04
         variant:
           - desktop
           # - default

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - focal
           - jammy
           - noble
         variant:


### PR DESCRIPTION
https://discourse.ubuntu.com/t/extended-security-maintenance-for-ubuntu-20-04-focal-fossa-began-on-may-29-2025/61909