### PR TITLE
tests/cluster: disable Apparmor and snapd in nested container

### DIFF
--- a/tests/cluster
+++ b/tests/cluster
@@ -28,7 +28,8 @@ print_log() {
 
 # wait for u1 and u2 to be booted and have u1 and m1 probe u2's IPv4
 instance_connectivity_checks() {
-    lxc exec m1 -- sh -c "$(declare -f waitInstanceReady waitInstanceBooted); waitInstanceBooted u1; waitInstanceBooted u2"
+    lxc exec m1 -- sh -c "$(declare -f waitInstanceReady waitInstanceBooted); waitInstanceBooted u1"
+    lxc exec m1 -- sh -c "$(declare -f waitInstanceReady waitInstanceBooted); waitInstanceBooted u2"
     lxc exec m1 -- lxc list
     U2_IPV4="$(lxc exec m1 -- lxc list u2 -c4 --format=csv | cut -d' ' -f1)"
     # XXX: replace ping (not on -minimal images) by a TCP probe on ssh port


### PR DESCRIPTION
Even with `security.nesting=true`, the `apparmor.service` fails to start in nested containers:

```
root@m1:~# lxc exec u3 -- journalctl -o cat -u apparmor.service
Restarting AppArmor
Reloading AppArmor profiles
/sbin/apparmor_parser: Unable to replace "Discord".  /sbin/apparmor_parser: Access denied. You need policy admin privileges to manage profiles.
/sbin/apparmor_parser: Unable to replace "1password".  /sbin/apparmor_parser: Access denied. You need policy admin privileges to manage profiles.
Starting apparmor.service - Load AppArmor profiles...
/sbin/apparmor_parser: Unable to replace "transmission-cli".  /sbin/apparmor_parser: Access denied. You need policy admin privileges to manage profiles.
Error: At least one profile failed to load
apparmor.service: Main process exited, code=exited, status=1/FAILURE
apparmor.service: Failed with result 'exit-code'.
Failed to start apparmor.service - Load AppArmor profiles.
apparmor.service: Consumed 1.260s CPU time.
```