### PR TITLE
github: stub out `docker` test as it is temporarily broken

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,6 @@ jobs:
           - cpu-vm
           - devlxd-container
           - devlxd-vm
-          - docker
           - efi-vars-editor-vm
           - lxd-installer
           - lxd-user


### PR DESCRIPTION
It will be reintroduced when https://github.com/canonical/lxd/issues/15741 is addressed.