### PR TITLE
tests/cluster: hold the LXD snap from the source channel

### DIFF
--- a/tests/cluster
+++ b/tests/cluster
@@ -58,6 +58,11 @@ waitInstanceBooted m1
 # XXX: not using `--cohort=+` as this is an older LXD that will be upgraded later on
 lxc exec m1 -- snap install lxd --channel="$2" || lxc exec m1 -- snap refresh lxd --channel="$2"
 
+# The test runs a `snap refresh` on each cluster member and expects LXD not to be refreshed at this point
+# but it can happen if the channel has a new revision phasing in due to intentionally not using `--cohort=+`.
+# Holding the LXD snap prevents the `snap refresh` from triggering a cluster-wide LXD snap refresh too early.
+lxc exec m1 -- snap refresh --hold lxd
+
 lxc pause m1
 for i in $(seq 2 "${SIZE}"); do
     lxc copy m1 "m${i}"


### PR DESCRIPTION
Before this commit, one CI run failed with:

```
==> Upgrading the cluster
++ seq 3
+ for i in $(seq "${SIZE}")
+ lxc exec m1 -- snap wait system seed.loaded
+ lxc exec m1 -- snap refresh
2025-06-10T08:26:55Z INFO Waiting for "snap.lxd.daemon.service" to stop.
lxd 6.4-2336111 from Canonical** refreshed
+ lxc exec m1 -- snap changes
ID   Status  Spawn               Ready               Summary
1    Done    today at 08:25 UTC  today at 08:25 UTC  Initialize system state
2    Done    today at 08:25 UTC  today at 08:25 UTC  Install "lxd" snap from "latest/stable" channel
3    Done    today at 08:25 UTC  today at 08:25 UTC  Initialize device
4    Done    today at 08:26 UTC  today at 08:27 UTC  Refresh "lxd" snap

+ lxc exec m1 -- snap switch lxd --channel=latest/edge --cohort=+
"lxd" switched to the "latest/edge" channel and the "+" cohort

+ '[' 1 = 3 ']'
+ for i in $(seq "${SIZE}")
+ lxc exec m2 -- snap wait system seed.loaded
+ lxc exec m2 -- snap refresh
All snaps up to date.
+ lxc exec m2 -- snap changes
ID   Status  Spawn               Ready               Summary
1    Done    today at 08:25 UTC  today at 08:25 UTC  Initialize system state
2    Done    today at 08:25 UTC  today at 08:25 UTC  Install "lxd" snap from "latest/stable" channel
3    Done    today at 08:25 UTC  today at 08:25 UTC  Initialize device
4    Doing   today at 08:27 UTC  -                   Refresh "lxd" snap from "+" cohort
5    Done    today at 08:27 UTC  today at 08:27 UTC  Refresh all snaps: no updates

+ lxc exec m2 -- snap switch lxd --channel=latest/edge --cohort=+
error: snap "lxd" has "refresh-snap" change in progress
+ cleanup
```

At the time of the problem, `latest/stable` had a new revision phasing in. Since we intentionally do not use `--cohort=+` for installing the source version, the `snap refresh` that ran on `m1` caused an early cluster-wide refresh of the LXD snap as we can see on `m2` where the `snap switch lxd` command failed due to the LXD snap having changes in progress (due to the "please refresh" notification received from `m1`).

While we expect a cluster-wide refresh to occur, it must happen later on in the script when the last member (`i` and `SIZE` equal 3, so `m3`) triggers it:

```
echo "==> Upgrading the cluster"
for i in $(seq "${SIZE}"); do
    lxc exec "m${i}" -- snap wait system seed.loaded
    lxc exec "m${i}" -- snap refresh
    # XXX: there should be no refresh ongoing but we've seen races before so let's collect evidences
    lxc exec "m${i}" -- snap changes
    lxc exec "m${i}" -- snap switch lxd --channel="$3" --cohort=+
    if [ "$i" = "${SIZE}" ]; then
        lxc exec "m${i}" -- timeout 10m snap refresh lxd
    fi
done
```