### PR TITLE
tests/network-routed: install iputils-ping if not present already

### DIFF
--- a/tests/network-routed
+++ b/tests/network-routed
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eux
 
+# Install dependencies
+install_deps iputils-ping
+
 # Install LXD
 install_lxd
 


### PR DESCRIPTION
This mirrors what `tests/network-ovn` does.
It makes the script compatible with `ubuntu-minimal-daily:24.04` image like one would get:

```
$ lxc launch ubuntu-minimal-daily:24.04 v1 --vm -p lxd-ci
root@v1:~# cd lxd-ci/
root@v1:~/lxd-ci# ./bin/local-run tests/network-routed latest/edge
...
```