### PR TITLE
tests/devlxd: Test cloud-init and metadata output

### DIFF
--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -73,8 +73,11 @@ lxc config set v1 security.devlxd true
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0 | jq
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/devices | jq
 lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/config | jq
-lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'instance-id:'
-lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data | grep -q 'local-hostname:'
+
+# Ensure that the outputed metadata is in correct format.
+META_DATA="$(lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.socket/1.0/meta-data)"
+grep -xE 'instance-id: [^ ]{36}' <<< "${META_DATA}"
+grep -xF 'local-hostname: v1' <<< "${META_DATA}"
 
 if hasNeededAPIExtension instance_ready_state; then
   # test instance Ready state

--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -79,6 +79,19 @@ META_DATA="$(lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock http://custom.so
 grep -xE 'instance-id: [^ ]{36}' <<< "${META_DATA}"
 grep -xF 'local-hostname: v1' <<< "${META_DATA}"
 
+# Test cloud-init user-data.
+# Ensure the header is preserved and the outputed value is not escaped.
+cloudInitUserData="#cloud-config
+package_update: false
+package_upgrade: false
+runcmd:
+- echo test"
+
+lxc config set v1 cloud-init.user-data "${cloudInitUserData}"
+out=$(lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock lxd/1.0/config/cloud-init.user-data)
+[ "${out}" = "${cloudInitUserData}" ]
+lxc config unset v1 cloud-init.user-data
+
 if hasNeededAPIExtension instance_ready_state; then
   # test instance Ready state
   lxc exec v1 -- curl -s --unix-socket /dev/lxd/sock -X PATCH -d '{"state":"Ready"}' http://custom.socket/1.0


### PR DESCRIPTION
In the name of the recent regression, this checks that the output from `/1.0/config/<key>` and `/1.0/meta-data` is properly formatted and is not escaped.