### PR TITLE
github: set a timeout for running actions/image-test

### DIFF
--- a/.github/workflows/image-almalinux.yml
+++ b/.github/workflows/image-almalinux.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -80,6 +82,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -83,6 +85,8 @@ jobs:
       - name: Test VM image
         uses: ./.github/actions/image-test
         if: contains(env.type, 'vm')
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         with:
           type: vm
           target: ${{ env.target }}

--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -68,6 +70,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-amazonlinux.yml
+++ b/.github/workflows/image-amazonlinux.yml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -96,6 +98,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-archlinux.yml
+++ b/.github/workflows/image-archlinux.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -89,6 +91,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-busybox.yml
+++ b/.github/workflows/image-busybox.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -66,6 +68,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -86,6 +88,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -77,6 +79,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -64,6 +66,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -79,6 +81,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-funtoo.yml
+++ b/.github/workflows/image-funtoo.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -65,6 +67,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -69,6 +71,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-kali.yml
+++ b/.github/workflows/image-kali.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -67,6 +69,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -70,6 +72,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-nixos.yml
+++ b/.github/workflows/image-nixos.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -70,6 +72,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -74,6 +76,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -87,6 +89,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -77,6 +79,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -80,6 +82,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-rockylinux.yml
+++ b/.github/workflows/image-rockylinux.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -80,6 +82,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -64,6 +66,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -85,6 +87,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm

--- a/.github/workflows/image-voidlinux.yml
+++ b/.github/workflows/image-voidlinux.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Test container image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 20
         if: contains(env.type, 'container')
         with:
           type: container
@@ -76,6 +78,8 @@ jobs:
 
       - name: Test VM image
         uses: ./.github/actions/image-test
+        # avoid runaway test burning 6 hours of CI
+        timeout-minutes: 40
         if: contains(env.type, 'vm')
         with:
           type: vm


### PR DESCRIPTION
Booting a container and a VM to run some basic tests should be relatively quick. We've seen a couple of failures where VMs would not reboot properly and burn the through the whole 6 hours limit imposed by GH.