### PR TITLE
tests/conversion: Remove passt package

### DIFF
--- a/tests/conversion
+++ b/tests/conversion
@@ -11,6 +11,7 @@ set -eu
 . /etc/os-release
 if dpkg --compare-versions "${VERSION_ID}" ge 24.04; then
       install_deps jq unzip virt-v2v
+      apt-get remove passt
 else
       install_deps jq unzip
 fi


### PR DESCRIPTION
Removing the `passt` package fixes the issue:
```
PID file open: Permission denied
libguestfs: trace: v2v: launch = -1 (error)
virt-v2v-in-place: error: libguestfs error: passt exited with status 1
```

Thanks to @mihalicyn, we found that when `passt` package is present on the system, `virt-v2v` tries to use it to emulate networking for unprivileged namespaces. However, when there is no `passt` present, this part is simply skipped due to missing package.

passt: https://passt.top/passt/about/