### PR TITLE
Revert "github: skip `pylxd` on `latest/{edge,candidate}`"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -287,11 +287,6 @@ jobs:
             track: "5.0/candidate"
           - os: 24.04
             track: "5.0/edge"
-          # known broken (https://github.com/canonical/pylxd/issues/650)
-          - test: pylxd
-            track: "latest/edge"
-          - test: pylxd
-            track: "latest/candidate"
 
     steps:
       - name: Tune disk performance


### PR DESCRIPTION
This reverts commit 50b9668d9431a72ca7740a2eee97c22c8c946bcd.

As we have modified LXD to only do Content-Type checks for browsers, so these tests should pass now.