### PR TITLE
tests/gpu-container: No need to use ZFS here

### DIFF
--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -39,7 +39,7 @@ IMAGE="${TEST_IMG:-ubuntu-daily:24.04}"
 nvidia-smi
 
 # Configure LXD
-lxc storage create default zfs
+lxc storage create default dir
 lxc profile device add default root disk path=/ pool=default
 lxc network create lxdbr0
 lxc profile device add default eth0 nic network=lxdbr0 name=eth0


### PR DESCRIPTION
There's no snapshots or multiple instance launches.

Using ZFS prevents testing on older hosts without supported ZFS.