### PR TITLE
github: more aggressively retry SFTP uploads in `actions/images-upload`

### DIFF
--- a/.github/actions/image-upload/action.yml
+++ b/.github/actions/image-upload/action.yml
@@ -59,7 +59,7 @@ runs:
         # First upload contents to the temporary dir and once fully uploaded
         # move the directory to the final destination to avoid potential race
         # where simplestream-maintainer includes partially uploaded images.
-        sftp -oHostKeyAlgorithms=ssh-ed25519 -P ${SSH_PORT} -oConnectionAttempts=3 -oConnectTimeout=5 -b - "${SSH_USER}@${SSH_HOST}" <<EOF
+        sftp -oHostKeyAlgorithms=ssh-ed25519 -P ${SSH_PORT} -oConnectionAttempts=10 -oConnectTimeout=10 -b - "${SSH_USER}@${SSH_HOST}" <<EOF
             put -R "${SRC_DIR}"-upload/*
             rename "${IMG_DIR}/.${VERSION}" "${IMG_DIR}/${VERSION}"
             bye


### PR DESCRIPTION
In the previous upload batch, multiple images failed to connect despite the 3 quick retries:

```
Thu, 24 Jul 2025 00:12:24 GMT + sftp -oHostKeyAlgorithms=ssh-ed25519 -P 922 -oConnectionAttempts=3 -oConnectTimeout=5 -b - imageserver@images.lxd.canonical.com
Thu, 24 Jul 2025 00:12:42 GMT ssh: connect to host images.lxd.canonical.com port 922: Connection timed out
Thu, 24 Jul 2025 00:12:42 GMT Connection closed
```

By spacing out the retries more and trying more time, hopefully, whatever connectivity hiccup we are facing will be shorter.

While 10 retries sounds a bit much, it's still quicker than the initial 135s of delay on connection failure and it is also much cheaper to retry the upload rather than re-run the whole workflow that builds the image again just to re-attempt the upload.