### PR TITLE
Revert "images/debian: workaround debian bugs causing apparmor failures"

### DIFF
--- a/images/debian.yaml
+++ b/images/debian.yaml
@@ -1426,26 +1426,5 @@ actions:
   variants:
   - cloud
 
-- trigger: post-files
-  action: |-
-    #!/bin/sh
-    set -eux
-    # Workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1103503
-    # and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1104344
-    [ -e /etc/apparmor.d/usr.sbin.dhclient ] || exit 0
-
-    # Check if usr.sbin.dhclient tries to include local/sbin.dhclient. If not, nothing to do.
-    grep -qF "include <local/sbin.dhclient>" /etc/apparmor.d/usr.sbin.dhclient || exit 0
-
-    # If local/sbin.dhclient exists, nothing to do.
-    [ -e /etc/apparmor.d/local/sbin.dhclient ] && exit 0
-
-    # Otherwise, create an empty file to please apparmor.service
-    mkdir -p /etc/apparmor.d/local
-    touch /etc/apparmor.d/local/sbin.dhclient
-  releases:
-  - sid
-  - trixie
-
 mappings:
   architecture_map: debian


### PR DESCRIPTION
This reverts commit 21a990874e68680c6cec2ad6a5a23186c9260458.

The fixed package version `4.4.3-P1-8` has made its way into Sid and Trixie according to: https://tracker.debian.org/pkg/isc-dhcp