### PR TITLE
github: tweak image building/publication schedule

### DIFF
--- a/.github/actions/image-upload/action.yml
+++ b/.github/actions/image-upload/action.yml
@@ -59,8 +59,14 @@ runs:
         # First upload contents to the temporary dir and once fully uploaded
         # move the directory to the final destination to avoid potential race
         # where simplestream-maintainer includes partially uploaded images.
-        sftp -oHostKeyAlgorithms=ssh-ed25519 -P ${SSH_PORT} -oConnectionAttempts=10 -oConnectTimeout=10 -b - "${SSH_USER}@${SSH_HOST}" <<EOF
-            put -R "${SRC_DIR}"-upload/*
-            rename "${IMG_DIR}/.${VERSION}" "${IMG_DIR}/${VERSION}"
-            bye
-        EOF
+        JITTER="$((RANDOM % 10))"
+        for attempt in 1 2 3; do
+          sftp -oHostKeyAlgorithms=ssh-ed25519 -P ${SSH_PORT} -oConnectionAttempts=5 -oConnectTimeout=5 -b - "${SSH_USER}@${SSH_HOST}" <<EOF
+              put -R "${SRC_DIR}"-upload/*
+              rename "${IMG_DIR}/.${VERSION}" "${IMG_DIR}/${VERSION}"
+              bye
+          EOF && exit 0
+
+          DELAY=$((JITTER + attempt * 5))
+          echo "Attempt ${attempt}/3 failed, waiting ${DELAY}s before retrying..."
+        done

--- a/.github/workflows/image-almalinux.yml
+++ b/.github/workflows/image-almalinux.yml
@@ -2,8 +2,8 @@ name: AlmaLinux
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '0 0 * * 1-5'   # Build amd64
+    - cron: '15 0 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -29,7 +29,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 0 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -2,8 +2,8 @@ name: Alpine
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '30 0 * * 1-5'  # Build amd64
+    - cron: '45 0 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -32,7 +32,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 0 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -2,8 +2,8 @@ name: ALT Linux
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '0 1 * * 1-5'  # Build amd64
+    - cron: '15 1 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -29,7 +29,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 1 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-amazonlinux.yml
+++ b/.github/workflows/image-amazonlinux.yml
@@ -2,8 +2,8 @@ name: AmazonLinux
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '30 1 * * 1-5'  # Build amd64
+    - cron: '45 1 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -27,7 +27,7 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 1 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-archlinux.yml
+++ b/.github/workflows/image-archlinux.yml
@@ -2,8 +2,8 @@ name: ArchLinux
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '0 2 * * 1-5'   # Build amd64
+    - cron: '15 2 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -29,7 +29,7 @@ jobs:
           - cloud
           - desktop-gnome
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 2 * * 1-15') && 'arm64' || 'amd64' }}
         exclude:
           - {architecture: arm64, variant: cloud}
           - {architecture: arm64, variant: desktop-gnome}

--- a/.github/workflows/image-busybox.yml
+++ b/.github/workflows/image-busybox.yml
@@ -2,8 +2,8 @@ name: BusyBox
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '30 2 * * 1-5'  # Build amd64
+    - cron: '45 2 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -28,7 +28,7 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 2 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -2,8 +2,8 @@ name: CentOS
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '0 3 * * 1-5'   # Build amd64
+    - cron: '15 3 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -28,7 +28,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 3 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -2,8 +2,8 @@ name: Debian
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '30 3 * * 1-5'  # Build amd64
+    - cron: '45 3 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -31,7 +31,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 3 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -2,7 +2,7 @@ name: Devuan
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
+    - cron: '0 4 * * 1-5'  # Build amd64
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -2,8 +2,8 @@ name: Fedora
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '15 4 * * 1-5'  # Build amd64
+    - cron: '30 4 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -29,7 +29,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '30 4 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -2,7 +2,7 @@ name: Gentoo
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
+    - cron: '45 4 * * 1-5'  # Build amd64
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-kali.yml
+++ b/.github/workflows/image-kali.yml
@@ -2,8 +2,8 @@ name: Kali
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '0 5 * * 1-5'   # Build amd64
+    - cron: '15 5 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -28,7 +28,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 5 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -2,7 +2,7 @@ name: Linux Mint
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
+    - cron: '30 5 * * 1-5'  # Build amd64
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-nixos.yml
+++ b/.github/workflows/image-nixos.yml
@@ -2,8 +2,8 @@ name: NixOS
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '45 5 * * 1-5'  # Build amd64
+    - cron: '0 6 * * 1-5'   # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -28,7 +28,7 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 6 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -2,7 +2,7 @@ name: openEuler
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
+    - cron: '15 6 * * 1-5'  # Build amd64
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -2,8 +2,8 @@ name: OpenSUSE
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '30 6 * * 1-5'  # Build amd64
+    - cron: '45 6 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -30,7 +30,7 @@ jobs:
           - cloud
           - desktop-kde
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 6 * * 1-5') && 'arm64' || 'amd64' }}
         exclude:
           - {architecture: arm64, variant: desktop-kde}
           - {release: 15.6, variant: cloud}

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -2,8 +2,8 @@ name: OpenWrt
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '0 7 * * 1-5'   # Build amd64
+    - cron: '15 7 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -29,7 +29,7 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 7 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -2,8 +2,8 @@ name: Oracle
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '30 7 * * 1-5'  # Build amd64
+    - cron: '45 7 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -29,7 +29,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 7 * * 1-5') && 'arm64' || 'amd64' }}
         exclude:
           - {architecture: arm64, release: 8}
     env:

--- a/.github/workflows/image-rockylinux.yml
+++ b/.github/workflows/image-rockylinux.yml
@@ -2,8 +2,8 @@ name: RockyLinux
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '0 8 * * 1-5'  # Build amd64
+    - cron: '15 8 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -29,7 +29,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 8 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -2,7 +2,7 @@ name: Slackware
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
+    - cron: '30 8 * * 1-5'  # Build amd64
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -2,7 +2,7 @@ name: Ubuntu
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
+    - cron: '45 8 * * 1-5'  # Build amd64
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/image-voidlinux.yml
+++ b/.github/workflows/image-voidlinux.yml
@@ -2,8 +2,8 @@ name: VoidLinux
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Build amd64 (Daily on Mon-Fri at 00:00 UTC).
-    - cron: '0 0 * * 1'  # Build arm64 (Weekly on Monday at 00:00 UTC).
+    - cron: '0 9 * * 1-5'   # Build amd64
+    - cron: '15 9 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
@@ -27,7 +27,7 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 0 * * 1') && 'arm64' ||'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 9 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"


### PR DESCRIPTION
This change does two things:

* Spread out the image building/publication to avoid overloading `images:`
 * Build `arm64` images daily now that `arm64` runners are free
   (addresses parts of https://github.com/canonical/lxd/issues/15651)

This should help with the SFTP upload we have especially on Sundays because `arm64` and `amd64` builds were triggered at the exact same time for all distros.