### PR TITLE
Enable `arm64` images where possible

### DIFF
--- a/.github/workflows/image-almalinux.yml
+++ b/.github/workflows/image-almalinux.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 8
-          - 9
+          - 8  # EOL: 2029-05-01
+          - 9  # EOL: 2032-05-31
         variant:
           - default
           - cloud

--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -2,7 +2,7 @@ name: ALT Linux
 
 on:
   schedule:
-    - cron: '0 1 * * 1-5'  # Build amd64
+    - cron: '0 1 * * 1-5'   # Build amd64
     - cron: '15 1 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-amazonlinux.yml
+++ b/.github/workflows/image-amazonlinux.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 2023
+          - 2023  # EOL: 2026-06-30
         variant:
           - default
         architecture:

--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 9-Stream
+          - 9-Stream  # EOL: 2032-05-31
         variant:
           - default
           - cloud

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - bullseye
-          - sid
-          - bookworm
-          - trixie
+          - bullseye  # EOL: 2026-08-31
+          - sid       # EOL: never
+          - bookworm  # EOL: 2026-06-10
+          - trixie    # EOL: ?? (not officially released yet)
         variant:
           - default
           - cloud

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - chimaera
-          - daedalus
+          - chimaera   # EOL: 2026-08-15
+          - daedalus   # EOL: 2028-06-10
         variant:
           - default
           - cloud

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -2,19 +2,24 @@ name: Devuan
 
 on:
   schedule:
-    - cron: '0 4 * * 1-5'  # Build amd64
+    - cron: '0 4 * * 1-5'   # Build amd64
+    - cron: '15 4 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   devuan:
     if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
     # XXX: Ubuntu 24.04 debootstrap doesn't work with Devuan Chimera (oldoldstable). Revert this when dropping Chimera on 2026-08-15
-    runs-on: 'ubuntu-22.04'
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +30,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - 'amd64'
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 4 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -3,17 +3,22 @@ name: Gentoo
 on:
   schedule:
     - cron: '45 4 * * 1-5'  # Build amd64
+    - cron: '0 5 * * 1-5'   # Build arm64
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   gentoo:
     if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +28,7 @@ jobs:
           - openrc
           - systemd
         architecture:
-          - 'amd64'
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 5 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - current
+          - current  # EOL: never
         variant:
           - openrc
           - systemd

--- a/.github/workflows/image-kali.yml
+++ b/.github/workflows/image-kali.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - current
+          - current   # EOL: never
         variant:
           - default
           - cloud

--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - virginia  # EOL: April 2027
-          - xia       # EOL: April 2029
+          - virginia  # EOL: 2027-04-30
+          - xia       # EOL: 2029-04-30
         variant:
           - default
           - cloud

--- a/.github/workflows/image-nixos.yml
+++ b/.github/workflows/image-nixos.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - unstable
-          - 24.05
+          - unstable  # EOL: never
+          - 24.05     # EOL: 2024-12-31
         variant:
           - default
         architecture:

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -3,17 +3,22 @@ name: openEuler
 on:
   schedule:
     - cron: '15 6 * * 1-5'  # Build amd64
+    - cron: '30 6 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   openeuler:
     if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +28,7 @@ jobs:
           - default
           - cloud
         architecture:
-          - 'amd64'
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '30 6 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 24.03
+          - 24.03  # EOL: 2028-03-31
         variant:
           - default
           - cloud

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 15.6
-          - tumbleweed
+          - 15.6        # EOL: 2025-12-31
+          - tumbleweed  # EOL: never
         variant:
           - default
           - cloud

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -23,9 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - snapshot
-          - "24.10"
-          - 23.05
+          - snapshot  # EOL: never
+          - 24.10     # EOL: ??
+          - 23.05     # EOL: 2025-08-04
         variant:
           - default
         architecture:

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 8
-          - 9
+          - 8   # EOL: 2029-07-31
+          - 9   # EOL: 2032-06-30
         variant:
           - default
           - cloud

--- a/.github/workflows/image-rockylinux.yml
+++ b/.github/workflows/image-rockylinux.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 8
-          - 9
+          - 8   # EOL: 2029-05-31
+          - 9   # EOL: 2032-05-31
         variant:
           - default
           - cloud

--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - current
+          - current  # EOL: never
         variant:
           - default
         architecture:

--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -3,17 +3,22 @@ name: Slackware
 on:
   schedule:
     - cron: '30 8 * * 1-5'  # Build amd64
+    - cron: '45 8 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
       publish:
         type: boolean
         default: false
         description: Publish built image
+      build-arm64:
+        type: boolean
+        default: false
+        description: Build arm64 images
 
 jobs:
   slackware:
     if: github.event_name != 'schedule' || github.repository == 'canonical/lxd-ci'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -22,8 +27,7 @@ jobs:
         variant:
           - default
         architecture:
-          - amd64
-
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 8 * * 1-5') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -22,13 +22,8 @@ jobs:
           - noble  # EOL: 2029-04
         variant:
           - desktop
-          # - default
-          # - cloud
         architecture:
           - amd64
-          # - arm64
-        exclude:
-          - {variant: desktop, architecture: arm64}
 
     env:
       type: "container"


### PR DESCRIPTION
This brings the `arm64` image offering on par with `amd64` except for VM images that we cannot test (no nested virt on `arm64` runners yet) so we don't build/ship. This will close https://github.com/canonical/lxd/issues/15651

All the known EOL dates were added while at it.

Thing to note: the Devuan images are the last ones being built on a 22.04 runners but the built and tested fine even with the `ubuntu-22.04-arm` runners.