### PR TITLE
github: quote strings ending with `0` as it rendered as `24.1`

### DIFF
--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         release:
           - snapshot  # EOL: never
-          - 24.10     # EOL: ??
+          - "24.10"   # EOL: ??
           - 23.05     # EOL: 2025-08-04
         variant:
           - default


### PR DESCRIPTION
Fixes commit 2c041a48956d4896eb3793042669b4bf09814e91