### PR TITLE
github: do SFTP connectivity test in `actions/image-setup`

### DIFF
--- a/.github/actions/image-setup/action.yml
+++ b/.github/actions/image-setup/action.yml
@@ -12,6 +12,29 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check connectivity for SFTP upload
+      shell: bash
+      run: |
+        set -eux
+
+        # Try to get own public IP
+        MY_PUBLIC_IP="$(curl --silent --max-time 5 https://api.ipify.org || true)"
+        [ "${MY_PUBLIC_IP}" = "" ] && exit 0
+        command -v nc || exit 0
+
+        # Test connectivity to SFTP server
+        SUCCESS="false"
+        for attempt in 1 2 3 4 5; do
+          echo "Try to connect from ${MY_PUBLIC_IP}..."
+          if nc -w 5 -zv images.lxd.canonical.com 922; then
+            SUCCESS="true"
+            break
+          fi
+        done
+
+        # Fail the job if the connection did not succeed.
+        [ "${SUCCESS}" = "true" ]
+
     - name: Install dependencies
       shell: bash
       run: |


### PR DESCRIPTION
A `tcpdump` capture on the PS6 VM showed that failed upload were accompanied with exactly 0 traffic from GH reaching the PS6 VM. Since this traffic is subject to IP allow-lists, my current theory is that IS' list does not include an up to date list of GH possible IPv4 source addresses.

As such, it's best to test the connectivity before doing anything "expensive" with the GH runner. Also, when the connectivity will fail again, I'll be armed with the public IPv4 that was used for the upload test and this will let me correlate it with the allow-list maintained by IS.