### PR TITLE
tests/container-nesting: stop warning when fixing `/dev/zfs`'s perms

### DIFF
--- a/tests/container-nesting
+++ b/tests/container-nesting
@@ -64,9 +64,9 @@ for poolDriver in ${poolDriverList}; do
             #      Otherwise, the LXD storage pool creation will fail.
             zfsPerm=$(stat -c '%a' /dev/zfs)
             if [ $((zfsPerm & 7)) -eq 0 ]; then
-                echo "::warning::Workaround for ZFS permission is still in effect."
-                ls -la /dev/zfs
-                chmod 666 /dev/zfs
+                # It's udev's job to fix the perms but the rule for it ships in
+                # the zfsutils-linux package which might not be installed.
+                chmod 0666 /dev/zfs
             fi
         else
             echo "ZFS version ${zfsVersion} does not support ZFS delegation and cannot be used within nested containers."


### PR DESCRIPTION
Installing the package `zfsutils-linux` and rebooting fixes the problem thanks to this package including this `/lib/udev/rules.d/90-zfs.rules`:

```
SUBSYSTEM!="block|misc", GOTO="zfs_end"
ACTION!="add|change", GOTO="zfs_end"

ENV{ID_FS_TYPE}=="zfs", RUN+="/sbin/modprobe zfs"
ENV{ID_FS_TYPE}=="zfs_member", RUN+="/sbin/modprobe zfs"

KERNEL=="null", SYMLINK+="root"
SYMLINK=="null", SYMLINK+="root"

KERNEL=="zfs", MODE="0666", OPTIONS+="static_node=zfs"

LABEL="zfs_end"
```

Since it's perfectly OK for the `zfsutils-linux` package to not be present on a system, it's fine to manually fix up the permissions.