### PR TITLE
github: publish successfully tested images if in the main repo

### DIFF
--- a/.github/workflows/image-almalinux.yml
+++ b/.github/workflows/image-almalinux.yml
@@ -6,10 +6,6 @@ on:
     - cron: '15 0 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -94,7 +90,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -6,10 +6,6 @@ on:
     - cron: '45 0 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -96,7 +92,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -6,10 +6,6 @@ on:
     - cron: '15 1 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -85,7 +81,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-amazonlinux.yml
+++ b/.github/workflows/image-amazonlinux.yml
@@ -6,10 +6,6 @@ on:
     - cron: '45 1 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -108,7 +104,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-archlinux.yml
+++ b/.github/workflows/image-archlinux.yml
@@ -6,10 +6,6 @@ on:
     - cron: '15 2 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -103,7 +99,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-busybox.yml
+++ b/.github/workflows/image-busybox.yml
@@ -6,10 +6,6 @@ on:
     - cron: '45 2 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -80,7 +76,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -6,10 +6,6 @@ on:
     - cron: '15 3 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -100,7 +96,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -6,10 +6,6 @@ on:
     - cron: '45 3 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -91,7 +87,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -6,10 +6,6 @@ on:
     - cron: '15 4 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -83,7 +79,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -6,10 +6,6 @@ on:
     - cron: '30 4 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -93,7 +89,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -6,10 +6,6 @@ on:
     - cron: '0 5 * * 1-5'   # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -88,7 +84,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-kali.yml
+++ b/.github/workflows/image-kali.yml
@@ -6,10 +6,6 @@ on:
     - cron: '15 5 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -81,7 +77,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -5,10 +5,6 @@ on:
     - cron: '30 5 * * 1-5'  # Build amd64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
 
 jobs:
   mint:
@@ -84,7 +80,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-nixos.yml
+++ b/.github/workflows/image-nixos.yml
@@ -6,10 +6,6 @@ on:
     - cron: '0 6 * * 1-5'   # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -84,7 +80,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -6,10 +6,6 @@ on:
     - cron: '30 6 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -93,7 +89,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -6,10 +6,6 @@ on:
     - cron: '45 6 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -101,7 +97,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -6,10 +6,6 @@ on:
     - cron: '15 7 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -90,7 +86,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -6,10 +6,6 @@ on:
     - cron: '45 7 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -94,7 +90,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-rockylinux.yml
+++ b/.github/workflows/image-rockylinux.yml
@@ -6,10 +6,6 @@ on:
     - cron: '15 8 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -94,7 +90,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -5,10 +5,6 @@ on:
     - cron: '30 8 * * 1-5'  # Build amd64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
 
 jobs:
   slackware:
@@ -78,7 +74,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -5,10 +5,6 @@ on:
     - cron: '45 8 * * 1-5'  # Build amd64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
 
 jobs:
   ubuntu:
@@ -94,7 +90,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"

--- a/.github/workflows/image-voidlinux.yml
+++ b/.github/workflows/image-voidlinux.yml
@@ -6,10 +6,6 @@ on:
     - cron: '15 9 * * 1-5'  # Build arm64
   workflow_dispatch:
     inputs:
-      publish:
-        type: boolean
-        default: false
-        description: Publish built image
       build-arm64:
         type: boolean
         default: false
@@ -90,7 +86,7 @@ jobs:
 
       - name: Upload image
         uses: ./.github/actions/image-upload
-        if: github.event_name == 'schedule' || inputs.publish == true
+        if: github.repository == 'canonical/lxd-ci'
         with:
           target: ${{ env.target }}
           image_dir: "${{ env.distro }}/${{ matrix.release }}/${{ matrix.architecture }}/${{ matrix.variant }}"


### PR DESCRIPTION
This drops the `publish` input parameter of manually triggered workflows as
it's only goal was to prevent publication (tentative) from forked repos.
