### PR TITLE
tests/storage-vm: add HPE Alletra storage pool driver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ To run the VM storage tests using Pure Storage driver, provide the following env
 * `PURE_API_KEY`: Pure Storage API key.
 * `PURE_MODE`: Operation mode for the consumption of storage volumes. The default is `nvme`.
 
+# Running HPE Alletra Storage VM storage tests
+
+To run the VM storage tests using HPE Alletra Storage driver, provide the following environment variables:
+
+* `ALLETRA_WSAPI`: Address of the HTTP WSAPI gateway
+* `ALLETRA_WSAPI_VERIFY`: Whether to verify the HTTP WSAPI gateway's certificate. The default is `true`.
+* `ALLETRA_USERNAME`: Name of the user
+* `ALLETRA_PASSWORD`: Password of the user
+* `ALLETRA_CPG`: Common Provisioning Group (CPG) name
+* `ALLETRA_MODE`: Operation mode for the consumption of storage volumes. The default is `nvme`.
+
 # Infrastructure managed by IS
 
 The PS6 environment has inbound and outbound firewalling applied at the network edge. In order to access some external sites here are the firewall rules we added to firewall maintained by IS:

--- a/bin/helpers
+++ b/bin/helpers
@@ -388,6 +388,17 @@ createPureStoragePool() (
     pure.mode="${PURE_MODE:-nvme}"
 )
 
+# createAlletraStoragePool: creates a new storage pool using the HPE Alletra Storage driver.
+createAlletraStoragePool() (
+  lxc storage create "${1}" alletra \
+    alletra.wsapi.url="${ALLETRA_WSAPI}" \
+    alletra.wsapi.user.name="${ALLETRA_USERNAME}" \
+    alletra.wsapi.user.password="${ALLETRA_PASSWORD}" \
+    alletra.wsapi.verify="${ALLETRA_WSAPI_VERIFY:-true}" \
+    alletra.wsapi.cpg="${ALLETRA_CPG}" \
+    alletra.mode="${ALLETRA_MODE:-nvme}"
+)
+
 # createCertificateAndKey: creates a new key pair.
 createCertificateAndKey() (
   key_file="${1}"

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -75,6 +75,8 @@ for poolDriver in $poolDriverList; do
                 createPowerFlexPool "${poolName}"
         elif [ "${poolDriver}" = "pure" ]; then
                 createPureStoragePool "${poolName}"
+        elif [ "${poolDriver}" = "alletra" ]; then
+                createAlletraStoragePool "${poolName}"
         else
                 lxc storage create "${poolName}" "${poolDriver}" size=19GiB
                 lxc storage set "${poolName}" size=20GiB
@@ -342,7 +344,7 @@ for poolDriver in $poolDriverList; do
                 lxc storage set "${poolName}" volume.size 16GiB
         fi
 
-        if [ "${poolDriver}" = "lvm" ] || [ "${poolDriver}" = "lvm-thin" ] || [ "${poolDriver}" = "ceph" ] || [ "${poolDriver}" = "powerflex" ] || [ "${poolDriver}" = "pure" ] || [ "${poolDriver}" = "zfs" ]; then
+        if [ "${poolDriver}" = "lvm" ] || [ "${poolDriver}" = "lvm-thin" ] || [ "${poolDriver}" = "ceph" ] || [ "${poolDriver}" = "powerflex" ] || [ "${poolDriver}" = "pure" ] || [ "${poolDriver}" = "alletra" ] || [ "${poolDriver}" = "zfs" ]; then
                 echo "==> Change volume.block.filesystem on pool and create VM"
                 lxc storage set "${poolName}" volume.block.filesystem xfs
 
@@ -364,7 +366,7 @@ for poolDriver in $poolDriverList; do
                 [ "$(($(lxc exec v1 -- blockdev --getsize64 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root) / GiB))" -eq "16" ]
         fi
 
-        if [ "${poolDriver}" = "lvm" ] || [ "${poolDriver}" = "lvm-thin" ] || [ "${poolDriver}" = "ceph" ] || [ "${poolDriver}" = "powerflex" ] || [ "${poolDriver}" = "pure" ] || [ "${poolDriver}" = "zfs" ]; then
+        if [ "${poolDriver}" = "lvm" ] || [ "${poolDriver}" = "lvm-thin" ] || [ "${poolDriver}" = "ceph" ] || [ "${poolDriver}" = "powerflex" ] || [ "${poolDriver}" = "pure" ] || [ "${poolDriver}" = "alletra" ] || [ "${poolDriver}" = "zfs" ]; then
                 echo "==> Ensure the VM volume ignores volume.block.filesystem"
                 if [ "${poolDriver}" = "zfs" ]; then
                     # The VM config disk is not a zvol with ext4 on top but just a plain ZFS dataset so no block.filesystem is used
@@ -464,6 +466,8 @@ for poolDriver in $poolDriverList; do
                 createPowerFlexPool "${poolName}-2"
         elif [ "${poolDriver}" = "pure" ]; then
                 createPureStoragePool "${poolName}-2"
+        elif [ "${poolDriver}" = "alletra" ]; then
+                createAlletraStoragePool "${poolName}-2"
         else
                 lxc storage create "${poolName}-2" "${poolDriver}" size=20GiB
         fi
@@ -631,7 +635,7 @@ for poolDriver in $poolDriverList; do
 
         # Set the images_volume on supported drivers only.
         # Ceph RBD, PowerFlex and Pure are not supported to prevent concurrent mounts.
-        if [ "${poolDriver}" != "ceph"  ] && [ "${poolDriver}" != "powerflex" ] && [ "${poolDriver}" != "pure" ]; then
+        if [ "${poolDriver}" != "ceph"  ] && [ "${poolDriver}" != "powerflex" ] && [ "${poolDriver}" != "pure" ] && [ "${poolDriver}" != "alletra" ]; then
                 lxc storage volume create "${poolName}" images
                 lxc config set storage.images_volume "${poolName}"/images
         fi

--- a/tests/storage-volumes-vm
+++ b/tests/storage-volumes-vm
@@ -33,6 +33,8 @@ do
                 lxc storage create "${poolName}" lvm size=20GiB volume.size=5GB
 	elif [ "${poolDriver}" = "powerflex" ]; then
 		createPowerFlexPool "${poolName}"
+	elif [ "${poolDriver}" = "alletra" ]; then
+		createAlletraStoragePool "${poolName}"
 	else
 		lxc storage create "${poolName}" "${poolDriver}" size=20GB volume.size=5GB
 	fi
@@ -42,7 +44,7 @@ do
 	lxc init "${IMAGE}" v2 --vm -s "${poolName}"
 
 	echo "==> Create custom block volume and attach it to VM"
-	if [ "${poolDriver}" != "powerflex" ]; then
+	if [ "${poolDriver}" != "powerflex" ] && [ "${poolDriver}" != "alletra" ]; then
 		lxc storage volume create "${poolName}" vol1 --type=block size=10MB
 	else
 		lxc storage volume create "${poolName}" vol1 --type=block size=8GiB
@@ -50,7 +52,7 @@ do
 	lxc storage volume attach "${poolName}" vol1 v1
 
 	echo "==> Create custom volume and attach it to VM"
-	if [ "${poolDriver}" != "powerflex" ]; then
+	if [ "${poolDriver}" != "powerflex" ] && [ "${poolDriver}" != "alletra" ]; then
 		lxc storage volume create "${poolName}" vol4 size=10MB
 	else
 		lxc storage volume create "${poolName}" vol4 size=8GiB
@@ -208,7 +210,7 @@ do
 		echo "==> Instance root & snapshot volumes"
 
 		empty_vm_size=8KiB
-		if [ "${poolDriver}" = "powerflex" ]; then
+		if [ "${poolDriver}" = "powerflex" ] || [ "${poolDriver}" = "alletra" ]; then
 			empty_vm_size=8GiB
 		fi
 


### PR DESCRIPTION
https://github.com/canonical/lxd/pull/16288 passes all these tests:
```
export LXD_SIDELOAD_PATH=/home/user1/lxd-ci/lxd.debug
export ALLETRA_WSAPI=https://<secret>
export ALLETRA_WSAPI_VERIFY=false
export ALLETRA_USERNAME=<secret>
export ALLETRA_PASSWORD=<secret>
export ALLETRA_CPG=SSD_r6
./bin/local-run tests/storage-vm latest/stable alletra
./bin/local-run tests/storage-volumes-vm latest/stable alletra
```