### PR TITLE
bin/helpers: adjust HPE Alletra config option names

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -391,11 +391,11 @@ createPureStoragePool() (
 # createAlletraStoragePool: creates a new storage pool using the HPE Alletra Storage driver.
 createAlletraStoragePool() (
   lxc storage create "${1}" alletra \
-    alletra.wsapi.url="${ALLETRA_WSAPI}" \
-    alletra.wsapi.user.name="${ALLETRA_USERNAME}" \
-    alletra.wsapi.user.password="${ALLETRA_PASSWORD}" \
+    alletra.wsapi="${ALLETRA_WSAPI}" \
+    alletra.user.name="${ALLETRA_USERNAME}" \
+    alletra.user.password="${ALLETRA_PASSWORD}" \
     alletra.wsapi.verify="${ALLETRA_WSAPI_VERIFY:-true}" \
-    alletra.wsapi.cpg="${ALLETRA_CPG}" \
+    alletra.cpg="${ALLETRA_CPG}" \
     alletra.mode="${ALLETRA_MODE:-nvme}"
 )
 


### PR DESCRIPTION
After fixing some code review suggestions old config option names are no longer valid. We need to fix this.