### PR TITLE
tests/gpu-container: Only test CDI mode on LXD servers with CDI mode support

### DIFF
--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -117,14 +117,16 @@ sleep 1
 lxc exec c1 -- nvidia-smi
 
 # Test with fully-qualified CDI name
-echo "==> Testing adding a GPU with a fully-qualified CDI name"
-lxc config unset c1 nvidia.runtime
-lxc stop --force c1
-lxc config device remove c1 gpus
-lxc config device add c1 gpu0 gpu id="nvidia.com/gpu=0"
-lxc start c1
-[ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ]
-lxc exec c1 -- nvidia-smi
+if hasNeededAPIExtension "gpu_cdi"; then
+    echo "==> Testing adding a GPU with a fully-qualified CDI name"
+    lxc config unset c1 nvidia.runtime
+    lxc stop --force c1
+    lxc config device remove c1 gpus
+    lxc config device add c1 gpu0 gpu id="nvidia.com/gpu=0"
+    lxc start c1
+    [ "$(lxc exec c1 -- ls /dev/dri/ | grep -c '^card[0-9]')" = "1" ]
+    lxc exec c1 -- nvidia-smi
+fi
 
 echo "==> Cleaning up"
 lxc delete -f c1


### PR DESCRIPTION
Part of 5.0.5 testing