### PR TITLE
tests/container: use a larger loop dev

### DIFF
--- a/tests/container
+++ b/tests/container
@@ -5,7 +5,7 @@ set -eu
 install_lxd
 
 # Configure LXD
-lxd init --auto --storage-backend btrfs
+lxd init --auto --storage-backend btrfs --storage-create-loop 24
 
 # Test
 set -x


### PR DESCRIPTION
Apparently images got bigger:

```
+ lxc exec n1 -- lxc launch ubuntu-minimal-daily:25.10 n11
Launching n11

Retrieving image: metadata: 100% (915.56MB/s)

Retrieving image: rootfs: 1% (1.84MB/s)

Retrieving image: rootfs: 1% (1.84MB/s)
Error: Failed instance creation: write /var/snap/lxd/common/lxd/images/4cc7daf415337cc9c972356d937ebb177ea7620ce6112bdbfd831b6d2c819ac2.rootfs: no space left on device
```