### PR TITLE
github: move to a weekly build/publication cadence for `busybox`

### DIFF
--- a/.github/workflows/image-busybox.yml
+++ b/.github/workflows/image-busybox.yml
@@ -2,8 +2,9 @@ name: BusyBox
 
 on:
   schedule:
-    - cron: '30 2 * * 1-5'  # Build amd64
-    - cron: '45 2 * * 1-5'  # Build arm64
+    # XXX: weekly build cadence due to tarball releases only (no package to update)
+    - cron: '30 2 * * 1'  # Build amd64
+    - cron: '45 2 * * 1'  # Build arm64
   workflow_dispatch:
     inputs:
       build-arm64:
@@ -24,7 +25,7 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 2 * * 1-5') && 'arm64' || 'amd64' }}
+          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 2 * * 1') && 'arm64' || 'amd64' }}
     env:
       type: "container"
       distro: "${{ github.job }}"


### PR DESCRIPTION
Busybox is released as a single tarball once in a blue moon and there are not package to update. The point of rebuilding/publishing new images is mostly to pick up new images quickly but that is such a rare event that we can do a manual build when that happens.

We could in theory stick to a single build and publish but we'll stick to a weekly cadence to avoid the images to be considered stale and expunged from `images:`.

This should reduce the pressure on the apparently overloaded download mirror.