### PR TITLE
tests/network-ovn: Increase iteration count in load balancing test

### DIFF
--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -1206,7 +1206,7 @@ EOF
         u2_ip4_seen=0
         u2_ip6_seen=0
 
-        for _ in $(seq 5); do
+        for _ in $(seq 20); do
             [ "$(lxc exec u1 -- dig a +tcp "@${ip4AddressPrefix}.10" lxd.localdomain +short)" = "127.0.0.1" ] && u1_ip4_seen=$((u1_ip4_seen + 1))
             [ "$(lxc exec u1 -- dig aaaa +tcp "@${ip6AddressPrefix}::10" lxd.localdomain +short)" = "::1" ] && u1_ip6_seen=$((u1_ip6_seen + 1))
             [ "$(lxc exec u2 -- dig a +tcp "@${ip4AddressPrefix}.10" lxd.localdomain +short)" = "127.0.0.2" ] && u2_ip4_seen=$((u2_ip4_seen + 1))


### PR DESCRIPTION
As discussed https://github.com/canonical/lxd-ci/pull/593#issuecomment-3375609827, we should increase the iteration count for OVN load balancing test similar to [OVN system tests](https://github.com/ovn-org/ovn/blob/708707672e7c7d4a13aa53759cffff209b585d5e/tests/system-ovn.at#L1932-L1967).