### PR TITLE
bin/helpers: Do not set northbound_connection when using MicroOVN

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -260,7 +260,9 @@ configure_ovn() {
         echo "" > /var/log/ovn/ovn-controller.log
     else
         microovn status || microovn cluster bootstrap
-        lxc config set network.ovn.northbound_connection "ssl:127.0.0.1:6641"
+        if ! hasNeededAPIExtension ovn_dynamic_northbound_connection; then
+          lxc config set network.ovn.northbound_connection "ssl:127.0.0.1:6641"
+        fi
     fi
 }
 


### PR DESCRIPTION
This is needed to allow LXD to dynamically pick up the correct address for Northbound database from MicroOVN.

Follow-up to https://github.com/canonical/lxd/pull/17874.