### PR TITLE
tests/lxd-installer: improve handling of separated ZFS package

### DIFF
--- a/tests/lxd-installer
+++ b/tests/lxd-installer
@@ -58,26 +58,27 @@ test_lxd_installer() {
 test_lxd() {
     local instance="${1}"
     local release="${2}"
-    local vm_uname
 
-    vm_uname="$(lxc exec "${instance}" -- uname -r)"
-    echo "==> ${instance} (${release} with kernel: ${vm_uname})"
+    echo "==> ${instance} (${release})"
 
     # new Ubuntu releases have split out the ZFS kernel module into a separate
     # package, so check if modinfo can find it and if not install the package
-    # that provides it and ensure the LXD daemon is reloaded to be aware of it.
+    # that provides it and ensure it is usable by LXD (reload or reboot if needed).
     if ! lxc exec "${instance}" -- modinfo -F version zfs; then
       lxc exec "${instance}" -- apt-get update
-      # XXX: the linux-modules-zfs-generic metapackage is avoided as it might
-      # pull a module for a newer kernel than the one running in the VM, which
-      # would cause modprobe to fail with a version mismatch error. Instead we
-      # install the specific package for the running kernel.
-      lxc exec "${instance}" -- apt-get install --no-install-recommends -y linux-main-modules-zfs-"${vm_uname}"
+      lxc exec "${instance}" -- apt-get install --no-install-recommends -y linux-modules-zfs-generic
 
-      # If ZFS was installed after the LXD daemon was started, it needs to be reloaded to pick up the PATH to the right tools.
-      if lxc exec "${instance}" -- systemctl is-active --quiet snap.lxd.daemon.service; then
-        echo "==> Reloading LXD snap to pick up newly installed ZFS modules"
-        lxc exec "${instance}" -- systemctl reload snap.lxd.daemon.service
+      # Check if we were lucky and got a ZFS module directly usable with the running kernel.
+      if lxc exec "${instance}" -- modinfo -F version zfs; then
+        # If ZFS was installed after the LXD daemon was started, it needs to be reloaded to pick up the PATH to the right tools.
+        if lxc exec "${instance}" -- systemctl is-active --quiet snap.lxd.daemon.service; then
+          echo "==> Reloading LXD snap to pick up newly installed ZFS modules"
+          lxc exec "${instance}" -- systemctl reload snap.lxd.daemon.service
+        fi
+      else  # If not, we need to reboot the instance to get a newer kernel with ZFS support.
+        lxc restart "${instance}"
+        waitInstanceBooted "${instance}"
+        lxc exec "${instance}" -- modinfo -F version zfs
       fi
     fi
 


### PR DESCRIPTION
The `linux-main-modules-zfs-$(uname -r)` package might be yanked out of archive mirrors when the associated kernel is superseded/rolled forward. This forces a VM reboot to pick a `zfs.ko` compatible with the updated kernel.