### PR TITLE
Refine workaround for VM inside ctn

### DIFF
--- a/tests/storage-metadata
+++ b/tests/storage-metadata
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -eux
 
-# XXX: avoid known issue: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2147374
-# VM inside container causes a kernel NULL pointer dereference on 6.17 so skip those tests on 6.17 until the issue is fixed.
-if [[ "$(uname -r)" =~ ^6\.17\.0 ]]; then
+# XXX: workaround for https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2147374
+# VM inside container causes a kernel NULL pointer dereference on 6.17 kernels older than -24
+kernelVersion="$(uname -r | cut -d '-' -f 1-2)"
+if dpkg --compare-versions "${kernelVersion}" lt "6.17.0-24"; then
   echo "Skipping storage-metadata tests on kernel 6.17 that has a known issue"
   # shellcheck disable=SC2034
   FAIL=0

--- a/tests/vm-nesting
+++ b/tests/vm-nesting
@@ -28,9 +28,10 @@ if echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/"; then
 fi
 
 # XXX: workaround for https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2147374
-# VM inside container causes a kernel NULL pointer dereference on 6.17 so skip those tests on 6.17 until the issue is fixed.
-if [[ "$(uname -r)" =~ ^6\.17\.0 ]]; then
-	echo "::warning:: Skipping VM in container tests on kernel 6.17 due to a known issue"
+# VM inside container causes a kernel NULL pointer dereference on 6.17 kernels older than -24
+kernelVersion="$(uname -r | cut -d '-' -f 1-2)"
+if dpkg --compare-versions "${kernelVersion}" lt "6.17.0-24"; then
+	echo "::warning:: Skipping VM in container tests on kernel ${kernelVersion} due to a known issue (fixed in 6.17.0-24)"
 	VM_IN_CTN=0
 fi
 


### PR DESCRIPTION
I verified the Questing `-proposed` kernel and it indeed addresses https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2147374

The kernel still needs to travel some more before it reaches us:
* `questing-proposed` -> `questing-updates`
* Go through HWE backports so that it lands in `noble-updates`
* GHA runner images are updated to pick up the `-24-azure` variant

But with this PR, our tests will automatically re-enable the needed bits to exercise the fixed code paths.