### PR TITLE
tests: Account for `restricted.registries` project config option

### DIFF
--- a/tests/network-ovn
+++ b/tests/network-ovn
@@ -157,6 +157,11 @@ ovn_basic_tests() {
         -c features.networks=true \
         -c restricted=true
 
+    # Allow the project to access image registries.
+    if hasNeededAPIExtension "image_registries"; then
+        lxc project set testovn restricted.registries=allow
+    fi
+
     lxc profile device add default root disk path=/ pool=default --project testovn
 
     echo "==> Test we cannot create network in restricted project with no defined uplinks"

--- a/tests/storage-disks-vm
+++ b/tests/storage-disks-vm
@@ -223,6 +223,12 @@ lxc project create restricted \
   -c restricted=true \
   -c restricted.devices.disk=allow \
   -c restricted.devices.disk.paths="${testRoot}/allowed1,${testRoot}/allowed2"
+
+# Allow the project to access image registries.
+if hasNeededAPIExtension "image_registries"; then
+  lxc project set restricted restricted.registries=allow
+fi
+
 lxc project switch restricted
 lxc profile device add default root disk path="/" pool=default
 lxc profile device add default eth0 nic network=lxdbr0


### PR DESCRIPTION
This PR updates tests that are using restricted projects to account for the new `restricted.registries` config option.

It updates the `network-ovn` and `storage-disks-vm` to set `restricted.registries=allow` for their restricted projects. This ensures that instances can be created in these tests.