### PR TITLE
github: build `amd64` and `arm64` images on the same schedule trigger

### DIFF
--- a/.github/workflows/image-almalinux.yml
+++ b/.github/workflows/image-almalinux.yml
@@ -2,20 +2,14 @@ name: AlmaLinux
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'   # Build amd64
-    - cron: '15 0 * * 1-5'  # Build arm64
+    - cron: '0 0 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -33,7 +27,8 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 0 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -2,20 +2,14 @@ name: Alpine
 
 on:
   schedule:
-    - cron: '30 0 * * 1-5'  # Build amd64
-    - cron: '45 0 * * 1-5'  # Build arm64
+    - cron: '30 0 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -35,7 +29,8 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 0 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-alt.yml
+++ b/.github/workflows/image-alt.yml
@@ -2,20 +2,14 @@ name: ALT Linux
 
 on:
   schedule:
-    - cron: '0 1 * * 1-5'   # Build amd64
-    - cron: '15 1 * * 1-5'  # Build arm64
+    - cron: '0 1 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -32,7 +26,8 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 1 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-amazonlinux.yml
+++ b/.github/workflows/image-amazonlinux.yml
@@ -2,20 +2,14 @@ name: AmazonLinux
 
 on:
   schedule:
-    - cron: '30 1 * * 1-5'  # Build amd64
-    - cron: '45 1 * * 1-5'  # Build arm64
+    - cron: '30 1 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -31,7 +25,8 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 1 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-archlinux.yml
+++ b/.github/workflows/image-archlinux.yml
@@ -2,20 +2,14 @@ name: ArchLinux
 
 on:
   schedule:
-    - cron: '0 2 * * 1-5'   # Build amd64
-    - cron: '15 2 * * 1-5'  # Build arm64
+    - cron: '0 2 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -33,7 +27,8 @@ jobs:
           - cloud
           - desktop-gnome
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 2 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
         exclude:
           - {architecture: arm64, variant: cloud}
           - {architecture: arm64, variant: desktop-gnome}

--- a/.github/workflows/image-busybox.yml
+++ b/.github/workflows/image-busybox.yml
@@ -3,20 +3,14 @@ name: BusyBox
 on:
   schedule:
     # XXX: weekly build cadence due to tarball releases only (no package to update)
-    - cron: '30 2 * * 1'  # Build amd64
-    - cron: '45 2 * * 1'  # Build arm64
+    - cron: '30 2 * * 1'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -33,7 +27,8 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 2 * * 1') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -2,20 +2,14 @@ name: CentOS
 
 on:
   schedule:
-    - cron: '0 3 * * 1-5'   # Build amd64
-    - cron: '15 3 * * 1-5'  # Build arm64
+    - cron: '0 3 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -32,7 +26,8 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 3 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-debian.yml
+++ b/.github/workflows/image-debian.yml
@@ -2,20 +2,14 @@ name: Debian
 
 on:
   schedule:
-    - cron: '30 3 * * 1-5'  # Build amd64
-    - cron: '45 3 * * 1-5'  # Build arm64
+    - cron: '30 3 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -36,7 +30,8 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 3 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-devuan.yml
+++ b/.github/workflows/image-devuan.yml
@@ -2,20 +2,14 @@ name: Devuan
 
 on:
   schedule:
-    - cron: '0 4 * * 1-5'   # Build amd64
-    - cron: '15 4 * * 1-5'  # Build arm64
+    - cron: '0 4 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -35,7 +29,8 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 4 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
         exclude:
           - release: excalibur
             variant: cloud  # cloud-init not working on this sysvinit based distro

--- a/.github/workflows/image-fedora.yml
+++ b/.github/workflows/image-fedora.yml
@@ -2,20 +2,14 @@ name: Fedora
 
 on:
   schedule:
-    - cron: '15 4 * * 1-5'  # Build amd64
-    - cron: '30 4 * * 1-5'  # Build arm64
+    - cron: '15 4 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -33,7 +27,8 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '30 4 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-gentoo.yml
+++ b/.github/workflows/image-gentoo.yml
@@ -2,20 +2,14 @@ name: Gentoo
 
 on:
   schedule:
-    - cron: '45 4 * * 1-5'  # Build amd64
-    - cron: '0 5 * * 1-5'   # Build arm64
+    - cron: '45 4 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -32,7 +26,8 @@ jobs:
           - openrc
           - systemd
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '0 5 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-kali.yml
+++ b/.github/workflows/image-kali.yml
@@ -2,20 +2,14 @@ name: Kali
 
 on:
   schedule:
-    - cron: '0 5 * * 1-5'   # Build amd64
-    - cron: '15 5 * * 1-5'  # Build arm64
+    - cron: '0 5 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -32,7 +26,8 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 5 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-mint.yml
+++ b/.github/workflows/image-mint.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 

--- a/.github/workflows/image-openeuler.yml
+++ b/.github/workflows/image-openeuler.yml
@@ -2,20 +2,14 @@ name: openEuler
 
 on:
   schedule:
-    - cron: '15 6 * * 1-5'  # Build amd64
-    - cron: '30 6 * * 1-5'  # Build arm64
+    - cron: '15 6 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -32,7 +26,8 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '30 6 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-opensuse.yml
+++ b/.github/workflows/image-opensuse.yml
@@ -2,20 +2,14 @@ name: OpenSUSE
 
 on:
   schedule:
-    - cron: '30 6 * * 1-5'  # Build amd64
-    - cron: '45 6 * * 1-5'  # Build arm64
+    - cron: '30 6 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -34,7 +28,8 @@ jobs:
           - cloud
           - desktop-kde
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 6 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
         exclude:
           - {architecture: arm64, variant: desktop-kde}
           - {release: 15.6, variant: cloud}

--- a/.github/workflows/image-openwrt.yml
+++ b/.github/workflows/image-openwrt.yml
@@ -2,20 +2,14 @@ name: OpenWrt
 
 on:
   schedule:
-    - cron: '0 7 * * 1-5'   # Build amd64
-    - cron: '15 7 * * 1-5'  # Build arm64
+    - cron: '0 7 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -33,7 +27,8 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 7 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-oracle.yml
+++ b/.github/workflows/image-oracle.yml
@@ -2,20 +2,14 @@ name: Oracle
 
 on:
   schedule:
-    - cron: '30 7 * * 1-5'  # Build amd64
-    - cron: '45 7 * * 1-5'  # Build arm64
+    - cron: '30 7 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -33,7 +27,8 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '45 7 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
         exclude:
           - {architecture: arm64, release: 8}
     env:

--- a/.github/workflows/image-rockylinux.yml
+++ b/.github/workflows/image-rockylinux.yml
@@ -2,20 +2,14 @@ name: RockyLinux
 
 on:
   schedule:
-    - cron: '0 8 * * 1-5'  # Build amd64
-    - cron: '15 8 * * 1-5'  # Build arm64
+    - cron: '0 8 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -33,7 +27,8 @@ jobs:
           - default
           - cloud
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 8 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"

--- a/.github/workflows/image-slackware.yml
+++ b/.github/workflows/image-slackware.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 

--- a/.github/workflows/image-ubuntu.yml
+++ b/.github/workflows/image-ubuntu.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 

--- a/.github/workflows/image-voidlinux.yml
+++ b/.github/workflows/image-voidlinux.yml
@@ -2,20 +2,14 @@ name: VoidLinux
 
 on:
   schedule:
-    - cron: '0 9 * * 1-5'   # Build amd64
-    - cron: '15 9 * * 1-5'  # Build arm64
+    - cron: '0 9 * * 1-5'
   workflow_dispatch:
-    inputs:
-      build-arm64:
-        type: boolean
-        default: false
-        description: Build arm64 images
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.build-arm64 }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   # XXX: scheduled runs should not cancel manually triggered ones
   cancel-in-progress: ${{ !contains(github.event_name, 'schedule')}}
 
@@ -31,7 +25,8 @@ jobs:
         variant:
           - default
         architecture:
-          - ${{ (inputs.build-arm64 == true || github.event.schedule == '15 9 * * 1-5') && 'arm64' || 'amd64' }}
+          - amd64
+          - arm64
     env:
       type: "container"
       distro: "${{ github.job }}"


### PR DESCRIPTION
Previously, with 2 `cron` schedule meant the same workflow file was used to build `amd64` first and later `arm64`.

The README as a single link per image workflow which means the last image build to fire (`arm64`) was the one being visible losing visibility on `amd64`-only build/validation issues (like https://github.com/canonical/lxd/issues/18187).