### PR TITLE
tests/cluster: Support multi-step cross-track upgrades

### DIFF
--- a/tests/cluster
+++ b/tests/cluster
@@ -1,6 +1,105 @@
 #!/bin/bash
 set -eux
 
+# Known LXD snap tracks in ascending order. Update when a new track is opened.
+KNOWN_TRACKS=("5.0" "5.21" "6")
+
+# get_upgrade_chain returns the ordered list of channels to upgrade through.
+# The first element is the source (install) channel.
+# e.g. get_upgrade_chain "5.21/edge" => 5.21/stable 5.21/edge 6/edge
+get_upgrade_chain() {
+    local target="$1"
+
+    if [[ "${target}" != */* ]]; then
+        echo "ERROR: Invalid channel '${target}'. Expected format '<track>/<risk>'." >&2
+        exit 1
+    fi
+
+    local track="${target%%/*}"
+    local risk="${target#*/}"
+
+    case "${risk}" in
+        stable|candidate|beta|edge) ;;
+        *)
+            echo "ERROR: Invalid risk '${risk}' in channel '${target}'." >&2
+            exit 1
+            ;;
+    esac
+
+    # "latest" is a snap alias for the highest numbered track.
+    if [ "${track}" = "latest" ]; then
+        track="${KNOWN_TRACKS[-1]}"
+    fi
+
+    local track_found=0
+    for known in "${KNOWN_TRACKS[@]}"; do
+        if [ "${known}" = "${track}" ]; then
+            track_found=1
+            break
+        fi
+    done
+
+    if [ "${track_found}" = "0" ]; then
+        echo "ERROR: Unknown track '${track}'. Known tracks: ${KNOWN_TRACKS[*]}" >&2
+        echo "Please update KNOWN_TRACKS in tests/cluster." >&2
+        exit 1
+    fi
+
+    local src="${track}/stable"
+
+    # Workaround for dqlite SOCK_CLOEXEC/AppArmor issue on kernel 6.17.0.
+    if [[ "$(uname -r)" =~ ^6\.17\.0 ]]; then
+        src="${track}/candidate"
+    fi
+
+    local chain=("${src}")
+
+    if [ "${target}" != "${src}" ]; then
+        chain+=("${target}")
+    fi
+
+    # Cross-track upgrade to the head track when not already on it.
+    local head_track="${KNOWN_TRACKS[-1]}"
+    if [ "${track}" != "${head_track}" ]; then
+        chain+=("${head_track}/edge")
+    fi
+
+    echo "${chain[@]}"
+}
+
+upgrade_cluster() {
+    local dst_channel="$1"
+
+    echo "==> Upgrading the cluster to ${dst_channel}"
+    for i in $(seq "${SIZE}"); do
+        lxc exec "m${i}" -- sh -c "$(declare -f waitSnapdSeed); waitSnapdSeed"
+        lxc exec "m${i}" -- snap refresh
+        # XXX: there should be no refresh ongoing but we've seen races before so let's collect evidences
+        lxc exec "m${i}" -- snap changes
+        lxc exec "m${i}" -- snap switch lxd --channel="${dst_channel}" --cohort=+
+        if [ "$i" = "${SIZE}" ]; then
+            lxc exec "m${i}" -- timeout 10m snap refresh lxd
+        fi
+    done
+
+    echo "==> Wait for all members to be ONLINE"
+    wait_for_online_cluster
+
+    echo "==> Validating the cluster after upgrade to ${dst_channel}"
+    lxc exec m1 -- lxc info
+    lxc exec m1 -- lxc cluster list
+
+    echo "==> Verify that instances are still functional after upgrade to ${dst_channel}"
+    instance_connectivity_checks
+
+    echo "==> Restarting the cluster"
+    lxc restart --all
+    wait_for_online_cluster
+
+    echo "==> Verify that instances are still functional after cluster reboot"
+    instance_connectivity_checks
+}
+
 # Install LXD
 install_lxd
 
@@ -8,12 +107,24 @@ install_lxd
 lxd init --auto --storage-backend btrfs --storage-create-loop 5
 
 IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"
-SIZE="$1"
+SIZE="${1:-3}"
+# Accept both the new <count> <channel> and legacy <count> <src> <dst> invocations.
+if [ "$#" -ge 3 ]; then
+    CHANNEL="${3:-${LXD_SNAP_CHANNEL}}"
+else
+    CHANNEL="${2:-${LXD_SNAP_CHANNEL}}"
+fi
 
-if [ -z "${1:-""}" ] || [ -z "${2:-""}" ] || [ -z "${3:-""}" ]; then
-    echo "Usage: ${0} <count> <source channel> <destination channel>"
+read -r -a UPGRADE_CHAIN <<< "$(get_upgrade_chain "${CHANNEL}")"
+SRC_CHANNEL="${UPGRADE_CHAIN[0]}"
+
+if [ "${#UPGRADE_CHAIN[@]}" -lt 2 ]; then
+    echo "ERROR: Upgrade chain must have at least a source and one destination."
+    echo "Got: ${UPGRADE_CHAIN[*]}"
     exit 1
 fi
+
+echo "==> Upgrade chain: ${UPGRADE_CHAIN[*]}"
 
 echo "==> Deploying the cluster"
 
@@ -63,12 +174,12 @@ lxc launch "${IMAGE}" m1 -c security.nesting=true -c security.devlxd.images=true
 
 waitInstanceBooted m1
 
-# XXX: not using `--cohort=+` as this is an older LXD that will be upgraded later on
-lxc exec m1 -- snap install lxd --channel="$2" || lxc exec m1 -- snap refresh lxd --channel="$2"
+# XXX: not using '--cohort=+' as this is an older LXD that will be upgraded later on
+lxc exec m1 -- snap install lxd --channel="${SRC_CHANNEL}" || lxc exec m1 -- snap refresh lxd --channel="${SRC_CHANNEL}"
 
-# The test runs a `snap refresh` on each cluster member and expects LXD not to be refreshed at this point
-# but it can happen if the channel has a new revision phasing in due to intentionally not using `--cohort=+`.
-# Holding the LXD snap prevents the `snap refresh` from triggering a cluster-wide LXD snap refresh too early.
+# The test runs a 'snap refresh' on each cluster member and expects LXD not to be refreshed at this point
+# but it can happen if the channel has a new revision phasing in due to intentionally not using '--cohort=+'.
+# Holding the LXD snap prevents the 'snap refresh' from triggering a cluster-wide LXD snap refresh too early.
 lxc exec m1 -- snap refresh --hold lxd
 
 lxc pause m1
@@ -136,9 +247,8 @@ echo "==> Create test instances"
 for i in 1 2; do
   lxc exec m1 -- lxc launch "${IMAGE}" u"${i}"
   lxc exec m1 -- sh -c "$(declare -f waitInstanceReady); waitInstanceReady u${i}"
-  # Apparmor fails to start (`/sbin/apparmor_parser: Access denied. You need
-  # policy admin privileges to manage profiles.`) in nested containers which
-  # cascades to snapd as it requires Apparmor to be functional
+  # Apparmor fails to start in nested containers which cascades to snapd
+  # as it requires Apparmor to be functional
   lxc exec m1 -- lxc exec u"${i}" -- systemctl mask --now apparmor.service snapd.seeded.service snapd.service snapd.socket
   lxc exec m1 -- lxc exec u"${i}" -- systemctl reset-failed apparmor.service snapd.seeded.service snapd.service snapd.socket
 done
@@ -195,34 +305,9 @@ if [ "${TEST_RESTRICTED}" = "1" ]; then
   lxc query "/1.0/certificates/${restricted_metrics_fingerprint}" | jq -er '.projects[0] == "default"'
 fi
 
-echo "==> Upgrading the cluster"
-for i in $(seq "${SIZE}"); do
-    lxc exec "m${i}" -- sh -c "$(declare -f waitSnapdSeed); waitSnapdSeed"
-    lxc exec "m${i}" -- snap refresh
-    # XXX: there should be no refresh ongoing but we've seen races before so let's collect evidences
-    lxc exec "m${i}" -- snap changes
-    lxc exec "m${i}" -- snap switch lxd --channel="$3" --cohort=+
-    if [ "$i" = "${SIZE}" ]; then
-        lxc exec "m${i}" -- timeout 10m snap refresh lxd
-    fi
+for step_idx in $(seq 1 $(( ${#UPGRADE_CHAIN[@]} - 1 ))); do
+    upgrade_cluster "${UPGRADE_CHAIN[${step_idx}]}"
 done
-
-echo "==> Wait for all members to be ONLINE"
-wait_for_online_cluster
-
-echo "==> Validating the cluster"
-lxc exec m1 -- lxc info
-lxc exec m1 -- lxc cluster list
-
-echo "==> Verify that instances are still functional after the cluster upgrade"
-instance_connectivity_checks
-
-echo "==> Restarting the cluster"
-lxc restart --all
-wait_for_online_cluster
-
-echo "==> Verify that instances are still functional after the cluster reboot"
-instance_connectivity_checks
 
 echo "==> Check the certificates for its permissions after cluster upgrade"
 lxc query "/1.0/certificates/${unrestricted_fingerprint}" | jq -er '.restricted == false'


### PR DESCRIPTION
Refactor the cluster test script to infer the upgrade chain from a single target channel instead of requiring explicit source/destination arguments.

## Changes

- Add `get_upgrade_chain()` to compute the ordered upgrade path from a target channel. For example, `5.21/edge` produces the chain: `5.21/stable → 5.21/edge → latest/edge`.

- Extract upgrade logic into `upgrade_cluster()` so it can be called once per step in the chain.

- Add a `KNOWN_TRACKS` list that fails the test when an unrecognized track is encountered, ensuring CI goes red when new tracks are opened.

## New interface
    tests/cluster [<count>] [<channel>]
      count   : number of cluster members (default: 3)
      channel : target snap channel (default: LXD_SNAP_CHANNEL)

The existing invocation (`tests/cluster 3`) continues to work. It defaults to the `LXD_SNAP_CHANNEL` set by `bin/local-run`.

## References
- Depends-on: https://github.com/canonical/lxd/pull/18287
- Issue: https://github.com/canonical/lxd/issues/17175