### PR TITLE
Add Centos Stream 10

### DIFF
--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -21,7 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - 9-Stream  # EOL: 2032-05-31
+          - 9-Stream  # EOL: 2027-05-31
+          - 10-Stream # EOL: 2030-05-31
         variant:
           - default
           - cloud

--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -55,6 +55,7 @@ source:
   # RPM-GPG-KEY-CentOS-Official
   - |-
     -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v2.0.22 (GNU/Linux)
 
     mQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn
     rIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ
@@ -68,20 +69,20 @@ source:
     Gat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y
     m4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB
     tDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5
-    QGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB
-    Ah4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl
-    Gy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs
-    N3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD
-    vOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq
-    a0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw
-    byaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg
-    q4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X
-    407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z
-    V6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG
-    rCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32
-    o8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy
-    yy+mHmSv
-    =kkH7
+    QGNlbnRvcy5vcmc+iQI3BBMBCAAhAhsDBgsJCAcDAgYVCAIJCgsDFgIBAh4BAheA
+    BQJczFsaAAoJEAW1VbOEg8ZdvOgQAMFTGIQokADy5+CynFKjfO7R0VVpJxmYGVr1
+    TjnKaHmjxnJaYqoha9ukGgmLu0r+lJ42Kk6nREk1vlxfRAfiWd00Zkm+K3IMq1/D
+    E0heC2vX8qqjsLJs3jzq0hgNvo9X0uHDaA4J1BHsD8sE5in/f4SivjbngvFovRGU
+    1XLNCgoqpFNcROP18LqKUw8WtqgWdnYBa5i6D5qx+WMRX0NHNwcCMy1lz+sTFxIU
+    9mW6cLsMaacPGD8pUXIVli8P9Vlv3jBk1wFIqRgQPW01ph/3bM7pf9hyM9FAfU4X
+    AFcyb1oYI4/82EkICUe6jeuZrz67dPeLVAlYrGW4hp/825g0fqJHxPDp25GS4rAa
+    4RqyibLzNjSGdXYeLj2NcB/8OqaP+T1hv3JDaqe70QoYa/GIC4rh15NyXVbUP+LG
+    V4vUiL7mb9ynzvF5zYHJbcg4R7dOsiZHrMFwy7FZesQaVrXeJlxRcEj65rpm1ZtZ
+    mwAE1k2LsRkvLyr9hpZkXnMeOKYIPwpdmBjXNVNVbq7097OxZOYPPos+iZKMWfl4
+    UQnMsCVxonZtamdI4qEc3jMkSZPJKgOplGOms5jdY+EdSvsFWEQ0Snd3dChfU7DV
+    o4Rbcy5klwHrvuZIOLaovhyxuRPhP6gV9+gzpTK/7vrvDlFbbZE6s212mDZ13RWB
+    mTfAxz4h
+    =agO/
     -----END PGP PUBLIC KEY BLOCK-----
 
   variant: minimal
@@ -213,7 +214,6 @@ packages:
   - packages:
     - cronie
     - curl
-    - dhclient
     - glibc-langpack-en
     - hostname
     - initscripts
@@ -225,6 +225,12 @@ packages:
     - rsyslog
     - vim-minimal
     action: install
+
+  - packages:
+    - dhclient
+    action: install
+    releases:
+    - 9-Stream
 
   - packages:
     - cronie-anacron
@@ -279,6 +285,7 @@ packages:
 
   - packages:
     - grub2-efi-x64
+    - grubby
     action: install
     types:
     - vm
@@ -287,6 +294,7 @@ packages:
 
   - packages:
     - grub2-efi-aarch64
+    - grubby
     action: install
     types:
     - vm

--- a/images/centos.yaml
+++ b/images/centos.yaml
@@ -264,10 +264,20 @@ packages:
 
   - packages:
     - cloud-utils-growpart
+    action: install
+    types:
+    - vm
+    variants:
+    - cloud
+
+  - packages:
     - gdisk
     action: install
     types:
     - vm
+    releases:
+    - 8-Stream
+    - 9-Stream
     variants:
     - cloud
 


### PR DESCRIPTION
This PR is based on the work I already made to add support for Centos10 to lxc-ci

* https://github.com/lxc/lxc-ci/pull/916
* https://github.com/lxc/lxc-ci/pull/918
* https://github.com/lxc/lxc-ci/pull/919

For this to work, the lxd-imagebuilder tool also needs to get patched with the same changes that were made to distrobuilder.

* https://github.com/lxc/distrobuilder/pull/941

I already pushed the changes needed into a branch [here](https://github.com/canonical/lxd-imagebuilder/compare/main...dherrerace:lxd-imagebuilder:centos10-fix).

This is part of the work required to resolve https://github.com/canonical/lxd/issues/15677