### PR TITLE
github: switch mirror for CentOS

### DIFF
--- a/.github/workflows/image-centos.yml
+++ b/.github/workflows/image-centos.yml
@@ -68,7 +68,7 @@ jobs:
               -o image.release=${{ matrix.release }} \
               -o image.variant=${{ matrix.variant }} \
               -o source.variant=boot \
-              -o source.url=https://dfw.mirror.rackspace.com/centos-stream
+              -o source.url=https://mirror.pilotfiber.com/centos-stream
 
       - name: Print build artifacts
         run: ls -lah "${{ env.target }}"


### PR DESCRIPTION
The previous one is missing ISOs for `arm64`.