### PR TITLE
github: use `ServerAliveInterval` when sftp'ing in `actions/image-upload`

### DIFF
--- a/.github/actions/image-upload/action.yml
+++ b/.github/actions/image-upload/action.yml
@@ -67,6 +67,6 @@ runs:
         bye
         EOF
 
-        sftp -oHostKeyAlgorithms=ssh-ed25519 -P "${SSH_PORT}" -oConnectionAttempts=5 -oConnectTimeout=5 -b "${SFTP_BATCHFILE}" "${SSH_USER}@${SSH_HOST}"
+        sftp -oHostKeyAlgorithms=ssh-ed25519 -P "${SSH_PORT}" -oConnectionAttempts=5 -oConnectTimeout=5 -oServerAliveInterval=30 -b "${SFTP_BATCHFILE}" "${SSH_USER}@${SSH_HOST}"
 
         rm -f "${SFTP_BATCHFILE}"


### PR DESCRIPTION
Some SFTP uploads are failing after creating the `.${DATE_STAMP}` dir and leave no file behind:

```
Tue, 19 May 2026 15:59:01 GMT + SRC_DIR=/home/runner/build
Tue, 19 May 2026 15:59:01 GMT + ls -lah /home/runner/build
Tue, 19 May 2026 15:59:01 GMT total 1.2G
Tue, 19 May 2026 15:59:01 GMT drwxr-xr-x  2 runner runner  4.0K May 19 15:56 .
Tue, 19 May 2026 15:59:01 GMT drwxr-x--- 14 runner runner  4.0K May 19 15:59 ..
Tue, 19 May 2026 15:59:01 GMT -rw-r--r--  1 runner runner   386 May 19 15:56 SHA256SUMS
Tue, 19 May 2026 15:59:01 GMT -rw-r--r--  1 root   root   1020M May 19 15:56 disk.qcow2
Tue, 19 May 2026 15:59:01 GMT -rw-r--r--  1 runner runner   12K May 19 15:40 image.yaml
Tue, 19 May 2026 15:59:01 GMT -rw-r--r--  1 root   root    1.3K May 19 15:56 lxd.tar.xz
Tue, 19 May 2026 15:59:01 GMT -rw-r--r--  1 root   root    134M May 19 15:44 rootfs.squashfs
Tue, 19 May 2026 15:59:01 GMT -rw-r--r--  1 runner runner    14 May 19 15:56 serial
Tue, 19 May 2026 15:59:01 GMT ++ cat /home/runner/build/serial
Tue, 19 May 2026 15:59:01 GMT + VERSION=20260519_1540
Tue, 19 May 2026 15:59:01 GMT + mkdir -p /home/runner/build-upload/centos/9-Stream/amd64/cloud/.20260519_1540
Tue, 19 May 2026 15:59:01 GMT + mv /home/runner/build/SHA256SUMS /home/runner/build/disk.qcow2 /home/runner/build/image.yaml /home/runner/build/lxd.tar.xz /home/runner/build/rootfs.squashfs /home/runner/build/serial /home/runner/build-upload/centos/9-Stream/amd64/cloud/.20260519_1540
Tue, 19 May 2026 15:59:01 GMT ++ mktemp
Tue, 19 May 2026 15:59:01 GMT + SFTP_BATCHFILE=/tmp/tmp.0wdK0GOAlN
Tue, 19 May 2026 15:59:01 GMT + cat
Tue, 19 May 2026 15:59:01 GMT + sftp -oHostKeyAlgorithms=ssh-ed25519 -P 922 -oConnectionAttempts=5 -oConnectTimeout=5 -b /tmp/tmp.0wdK0GOAlN ...
Tue, 19 May 2026 15:59:04 GMT sftp> put -R "/home/runner/build"-upload/*
Tue, 19 May 2026 15:59:04 GMT Entering /home/runner/build-upload/centos/
Tue, 19 May 2026 15:59:04 GMT Entering /home/runner/build-upload/centos/9-Stream
Tue, 19 May 2026 15:59:04 GMT Entering /home/runner/build-upload/centos/9-Stream/amd64
Tue, 19 May 2026 15:59:04 GMT Entering /home/runner/build-upload/centos/9-Stream/amd64/cloud
Tue, 19 May 2026 15:59:04 GMT Entering /home/runner/build-upload/centos/9-Stream/amd64/cloud/.20260519_1540
Tue, 19 May 2026 16:15:25 GMT client_loop: send disconnect: Broken pipe
Tue, 19 May 2026 16:15:25 GMT Connection closed
Tue, 19 May 2026 16:15:25 GMT Error: Process completed with exit code 255.
```

Those failures are potentially due to aggressive firewall/NAT. Using a keepalive should avoid this or at the very least abort more swiftly.