### PR TITLE
Revert "github: tweak `tests/cluster` to start with candidate channel"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -421,11 +421,6 @@ jobs:
           if [ "${TEST_SCRIPT}" = "cluster" ]; then
             dst_track="${MATRIX_TRACK}"
             src_track="$(echo "${dst_track}" | cut -d/ -f1)/stable"
-            # `*/stable` are not all working on 6.17 due to dqlite bug
-            # use `*/candidate` which has the fixed dqlite.
-            if [[ "$(uname -r)" =~ ^6\.17\.0 ]]; then
-              src_track="$(echo "${dst_track}" | cut -d/ -f1)/candidate"
-            fi
             EXTRA_ARGS="${EXTRA_ARGS:-3} ${src_track} ${MATRIX_TRACK}"
           elif [ "${TEST_SCRIPT}" = "network-ovn" ]; then
             if [ -n "${EXTRA_ARGS}" ]; then


### PR DESCRIPTION
This reverts commit b0bd2867f324e570f3fa8734cf58a2c8880ad40b.