### PR TITLE
Test: Extend PowerFlex test capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ To run the VM storage tests on the Dell PowerFlex driver, provide the following 
 * `POWERFLEX_USER`: Name of the PowerFlex user
 * `POWERFLEX_PASSWORD`: Password of the PowerFlex user
 * `POWERFLEX_MODE`: Operation mode for the consumption of storage volumes. The default is `nvme`.
+* `POWERFLEX_SNAPSHOT_COPY`: If enabled, the driver uses PowerFlex snapshots for optimized copy
 
 Use a PowerFlex storage pool (`POWERFLEX_POOL`) which has zero-padding enabled.
 Using non zero-padding enabled pools is not allowed.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ To test a custom snap of LXD, you can set the `LXD_SNAP_PATH` environment variab
 LXD_SNAP_PATH=/tmp/lxd_0+git.89550582_amd64.snap ./bin/local-run tests/interception latest/edge
 ```
 
+To use the system's ZFS tools, you can set the `LXD_ZFS_EXTERNAL` environment variable.
+
+```sh
+LXD_ZFS_EXTERNAL=1 ./bin/local-run tests/interception latest/edge
+```
+
 To run `tests/network-ovn` against various OVN implementation:
 
 ```sh

--- a/bin/helpers
+++ b/bin/helpers
@@ -322,6 +322,10 @@ install_lxd() (
         mount --bind "${LXD_AGENT_SIDELOAD_PATH}" /snap/lxd/current/bin/lxd-agent
     fi
 
+    if [ -n "${LXD_ZFS_EXTERNAL:-}" ]; then
+        snap set lxd zfs.external=true
+    fi
+
     if [ "$start_daemon" = "true" ]; then
         lxd waitready --timeout=300
     fi

--- a/bin/helpers
+++ b/bin/helpers
@@ -371,6 +371,10 @@ createPowerFlexPool() (
     powerflex.user.name="${POWERFLEX_USER}" \
     powerflex.user.password="${POWERFLEX_PASSWORD}" \
     powerflex.mode="${POWERFLEX_MODE:-nvme}"
+
+  if [ -n "${POWERFLEX_SNAPSHOT_COPY:-}" ]; then
+    lxc storage set "${1}" powerflex.snapshot_copy=true
+  fi
 )
 
 # createPowerStorePool: creates a new storage pool using the PowerStore driver.

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -49,9 +49,11 @@ if echo "${poolDriverList}" | grep -qwF "zfs" && grep -qwFm1 zfs_external /snap/
     lxc storage delete zexternal
     ! zpool status zexternal || false
 
-    echo "==> Use internal ZFS tools"
-    snap unset lxd zfs.external
-    systemctl restart snap.lxd.daemon.service
+    echo "==> Use internal ZFS tools if not explicitly set to use external"
+    if [ -z "${LXD_ZFS_EXTERNAL:-}" ]; then
+        snap unset lxd zfs.external
+        systemctl restart snap.lxd.daemon.service
+    fi
 else
     echo "==> Skipping zfs.external test"
 fi


### PR DESCRIPTION
As part of https://github.com/canonical/lxd/pull/18391 I found it helpful to have another `POWERFLEX_SNAPSHOT_COPY` var that allows running the tests in the more optimized mode.

Volumes in PowerFlex 5 now support optimized copy and refresh even if they have snapshots. Therefore setting `POWERFLEX_SNAPSHOT_COPY=1` allows getting a good test coverage out of this feature.

In addition this PR adds a `LXD_ZFS_EXTERNAL` var to not run into troubles when running the tests using latest LXD on 22.04 hosts.