### PR TITLE
github: remove recently broken `alpine/3.21/cloud`

### DIFF
--- a/.github/workflows/image-alpine.yml
+++ b/.github/workflows/image-alpine.yml
@@ -31,6 +31,8 @@ jobs:
         architecture:
           - amd64
           - arm64
+        exclude:
+          - {release: "3.21", variant: cloud}
     env:
       type: "container"
       distro: "${{ github.job }}"


### PR DESCRIPTION
```
+ lxc exec container-alpine-cloud-unpriv -- cloud-init status --wait --long

status: done
extended_status: degraded done
boot_status_code: enabled-by-sysvinit
last_update: Thu, 01 Jan 1970 00:00:04 +0000
detail: DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net]
errors: []
recoverable_errors:
WARNING:
	- Could not find module named cc_reset_rmc (searched ['cc_reset_rmc', 'cloudinit.config.cc_reset_rmc'])
===> FAIL: cloud-init reboot: container-alpine-cloud-unpriv
```

The 3.21 release is going EOL in November 2026 so let's not too spend too much time on it.