### PR TITLE
CI fixes for `core26`

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -492,6 +492,12 @@ cleanup() {
         rm /var/crash/dnsmasq*
     fi
 
+    # Ignore fuse_worker crashes.
+    if compgen -G "/var/crash/fuse_worker*" > /dev/null 2>&1; then
+        echo "::notice::==> CORE: fuse_worker core dump ignored"
+        rm /var/crash/fuse_worker*
+    fi
+
     if [ -n "$(ls -A /var/crash/)" ]; then
         echo "CORE: coredump found during cleanup, forcing failure"
         FAIL=1

--- a/tests/lxd-user
+++ b/tests/lxd-user
@@ -11,18 +11,26 @@ install_lxd
 # Create testuser account
 useradd -m testuser -G lxd --uid 5000
 
+# Allow testuser to run lxd-user daemon without creating a systemd user session
+# See https://forum.snapcraft.io/t/46210
+loginctl enable-linger testuser
+sleep 3 # allow time for the session to be usable
+
 # Access lxd-user
 lxc_user info
 lxc_user project list
 lxc_user project list -f csv | grep '^user-5000.*,"User restricted project for ""testuser"" (5000)",'
 
-# Cleanup
-lxc project delete user-5000
-userdel -r testuser 2>/dev/null || true
-
 # Try to gracefully stop lxd-user daemon which allows coverage data to be
 # saved if needed.
 pkill -x lxd-user || pkill -x lxd-user.debug || true
+
+# End the user session
+loginctl terminate-user testuser
+
+# Cleanup
+lxc project delete user-5000
+userdel -r testuser 2>/dev/null
 
 # shellcheck disable=SC2034
 FAIL=0

--- a/tests/qemu-external-vm
+++ b/tests/qemu-external-vm
@@ -23,6 +23,9 @@ install_lxd
 lxd init --auto
 
 # Get the source
+if ! command -v git >/dev/null; then
+  install_deps git
+fi
 git clone --depth=1 "https://github.com/canonical/lxd-pkg-snap.git" -b "latest-edge"
 
 # Build qemu-for-lxd snap

--- a/tests/qemu-external-vm
+++ b/tests/qemu-external-vm
@@ -19,6 +19,11 @@ fi
 # Install LXD
 install_lxd
 
+# LXD 5.21 will remain based on `core24` but newer versions will move to `core26`
+# Look at the installed snap for a `gpu-XXYY` directory to know which `mesa-XXYY` snap to install and connect with.
+GPU_DIR="$(basename /snap/lxd/current/gpu-*)"
+GPU_VERSION="${GPU_DIR#gpu-}"
+
 # Configure LXD
 lxd init --auto
 
@@ -63,11 +68,11 @@ ls -la "${CACHE_PATH}/"
 
 snap install "${SNAP_TO_INSTALL_PATH}" --dangerous
 
-# install gpu-2404 interface snap
-snap install mesa-2404
+# install mesa snap providing the right GPU interface
+snap install "mesa-${GPU_VERSION}"
 
 # connect snaps
-snap connect lxd:gpu-2404 mesa-2404:gpu-2404
+snap connect "lxd:gpu-${GPU_VERSION}" "mesa-${GPU_VERSION}:gpu-${GPU_VERSION}"
 snap connect lxd:qemu-external qemu-for-lxd:qemu-external
 
 # let LXD to reload
@@ -81,7 +86,7 @@ journalctl --quiet --no-hostname --no-pager --boot=0 --unit=snap.lxd.daemon.serv
 lxc query /1.0 | jq '.environment.driver' | grep "qemu"
 lxc query /1.0 | jq '.environment.driver_version' | grep "(external)"
 
-# check that connection with mesa-2404 snap works
+# check that connection with the mesa snap works
 serverPID="$(lxc query /1.0 | jq .environment.server_pid)"
 grep -aF LIBGL_DRIVERS "/proc/${serverPID}/environ"
 

--- a/tests/qemu-external-vm
+++ b/tests/qemu-external-vm
@@ -88,7 +88,8 @@ lxc query /1.0 | jq '.environment.driver_version' | grep "(external)"
 
 # check that connection with the mesa snap works
 serverPID="$(lxc query /1.0 | jq .environment.server_pid)"
-grep -aF LIBGL_DRIVERS "/proc/${serverPID}/environ"
+# Look in LXD daemon env for a variable that was exported by the 'gpu-${GPU_VERSION}-provider-wrapper' script
+grep -aF VK_LAYER_PATH "/proc/${serverPID}/environ"
 
 # shellcheck disable=SC2034
 FAIL=0


### PR DESCRIPTION
Fixes:
* `cluster` (ignore the crash with `fuse_worker`)
* `lxd-user`
* `qemu-external-vm`