### PR TITLE
tests/gpu-mig: Use latest nvidia server-open driver

### DIFF
--- a/tests/gpu-mig
+++ b/tests/gpu-mig
@@ -10,8 +10,13 @@ fi
 
 # Install dependencies
 install_deps jq ubuntu-drivers-common
-RECOMMENDED_DRIVER="$(ubuntu-drivers devices 2>/dev/null | awk '/nvidia-driver-.*recommended$/ {print $3}')"
+RECOMMENDED_DRIVER="$(ubuntu-drivers --gpgpu devices | awk '/-server-open/ {print $3}' | sort -V -r | head -n1)"
 INSTALL_RECOMMENDS=yes install_deps "${RECOMMENDED_DRIVER}"
+
+# Reload nvidia kernel module
+modprobe -r --remove-holders nvidia_drm || true
+modprobe -r --remove-holders nvidia || true
+modprobe --first-time nvidia
 
 # Install LXD
 install_lxd


### PR DESCRIPTION
This is consistent with how we install Nvidia drivers for the `gpu-container` test.