### PR TITLE
Improve `gpu-mig` test

### DIFF
--- a/tests/gpu-mig
+++ b/tests/gpu-mig
@@ -92,6 +92,54 @@ lxc exec nvidia-mig4 -- nvidia-smi
 # Make sure all 3 MIG devices are there (gpu{0,1,2})
 [ "$(lxc exec nvidia-mig4 -- nvidia-smi -L | grep -cwF MIG)" -eq 3 ]
 
+# Test CDI "id" notation as MIG selector (requires the gpu_mig_cdi API extension).
+if hasNeededAPIExtension "gpu_mig_cdi"; then
+  # Stop nvidia-mig3 to free UUID3 so the new container has exclusive use of the MIG slice.
+  lxc stop -f nvidia-mig3
+
+  lxc init "${IMAGE}" nvidia-mig5
+
+  # Verify CDI "id" is mutually exclusive with the "pci" parent selector.
+  if lxc config device add nvidia-mig5 gpu_bad gpu gputype=mig id="nvidia.com/mig=${UUID3}" pci="${first_card_pci_slot}"; then
+    echo "ERROR: combining CDI \"id\" with \"pci\" should be rejected" >&2
+    exit 1
+  fi
+
+  # Verify CDI "id" is mutually exclusive with the "vendorid"/"productid" parent selectors.
+  if lxc config device add nvidia-mig5 gpu_bad gpu gputype=mig id="nvidia.com/mig=${UUID3}" vendorid=10de productid="${first_card_product_id}"; then
+    echo "ERROR: combining CDI \"id\" with \"vendorid\"/\"productid\" should be rejected" >&2
+    exit 1
+  fi
+
+  # Verify CDI "id" is mutually exclusive with "mig.uuid".
+  if lxc config device add nvidia-mig5 gpu_bad gpu gputype=mig id="nvidia.com/mig=${UUID3}" mig.uuid="${UUID3}"; then
+    echo "ERROR: combining CDI \"id\" with \"mig.uuid\" should be rejected" >&2
+    exit 1
+  fi
+
+  # Verify CDI "id" is mutually exclusive with "mig.gi"+"mig.ci".
+  if lxc config device add nvidia-mig5 gpu_bad gpu gputype=mig id="nvidia.com/mig=${UUID3}" mig.gi=1 mig.ci=0; then
+    echo "ERROR: combining CDI \"id\" with \"mig.gi\"/\"mig.ci\" should be rejected" >&2
+    exit 1
+  fi
+
+  # Check MIG device is being passed through correctly when "id=nvidia.com/mig=<uuid>".
+  lxc config device add nvidia-mig5 gpu0 gpu gputype=mig id="nvidia.com/mig=${UUID3}"
+  lxc start nvidia-mig5
+  lxc exec nvidia-mig5 -- nvidia-smi
+  [ "$(lxc exec nvidia-mig5 -- nvidia-smi -L | grep -cwF MIG)" -eq 1 ]
+
+  # Verify the same MIG slice using the alternative "<dev_idx>:<mig_idx>" CDI form.
+  # UUID3 is the 3rd MIG slice on the only MIG-enabled GPU (Device 2 on that card).
+  first_card_nvml_idx="$(nvidia-smi -i "${first_card_pci_slot}" --query-gpu=index --format=csv,noheader,nounits)"
+  lxc stop -f nvidia-mig5
+  lxc config device remove nvidia-mig5 gpu0
+  lxc config device add nvidia-mig5 gpu0 gpu gputype=mig id="nvidia.com/mig=${first_card_nvml_idx}:2"
+  lxc start nvidia-mig5
+  lxc exec nvidia-mig5 -- nvidia-smi
+  [ "$(lxc exec nvidia-mig5 -- nvidia-smi -L | grep -cwF MIG)" -eq 1 ]
+fi
+
 # Wait for them to start and list
 lxc list
 
@@ -105,6 +153,9 @@ nvidia-smi -i "${first_card_pci_slot}" -mig 0
 
 echo "==> Cleaning up"
 lxc delete nvidia-mig1 nvidia-mig2 nvidia-mig3 nvidia-mig4
+if hasNeededAPIExtension "gpu_mig_cdi"; then
+  lxc delete nvidia-mig5
+fi
 lxc profile device remove default root
 lxc profile device remove default eth0
 lxc storage delete default

--- a/tests/gpu-mig
+++ b/tests/gpu-mig
@@ -37,15 +37,15 @@ identical_nvidia_gpus="$(lxc query /1.0/resources | jq -r '.gpu.cards | .[] | se
 first_card_pci_slot="$(lxc query /1.0/resources | jq -r '.gpu.cards | .[] | select(.driver == "nvidia") | .pci_address' | head -n1)"
 first_card_product_id="$(lxc query /1.0/resources | jq -r ".gpu.cards | .[] | select(.pci_address == \"${first_card_pci_slot}\") | .product_id")"
 
-# Setup MIG
-nvidia-smi -mig 1
-nvidia-smi mig -lgip
-nvidia-smi mig -cgi 2g.10gb,1g.5gb,1g.5gb
-nvidia-smi mig -lgi
-nvidia-smi mig -lcip
-nvidia-smi mig -cci 1g.5gb -gi 7
-nvidia-smi mig -cci 1g.5gb -gi 13
-nvidia-smi mig -cci 1c.2g.10gb,1c.2g.10gb -gi 5
+# Setup MIG on the first NVIDIA card only to keep the test deterministic on multi-GPU hosts.
+nvidia-smi -i "${first_card_pci_slot}" -mig 1
+nvidia-smi mig -i "${first_card_pci_slot}" -lgip
+nvidia-smi mig -i "${first_card_pci_slot}" -cgi 2g.10gb,1g.5gb,1g.5gb
+nvidia-smi mig -i "${first_card_pci_slot}" -lgi
+nvidia-smi mig -i "${first_card_pci_slot}" -lcip
+nvidia-smi mig -i "${first_card_pci_slot}" -cci 1g.5gb -gi 7
+nvidia-smi mig -i "${first_card_pci_slot}" -cci 1g.5gb -gi 13
+nvidia-smi mig -i "${first_card_pci_slot}" -cci 1c.2g.10gb,1c.2g.10gb -gi 5
 nvidia-smi
 
 UUIDS="$(nvidia-smi -L | sed -n "/(UUID: MIG-/ s/.* \(MIG-[^)]\+\))$/\1/p")"
@@ -99,9 +99,9 @@ lxc list
 lxc stop -f --all
 
 # Cleanup MIG
-nvidia-smi mig -dci
-nvidia-smi mig -dgi
-nvidia-smi -mig 0
+nvidia-smi mig -i "${first_card_pci_slot}" -dci
+nvidia-smi mig -i "${first_card_pci_slot}" -dgi
+nvidia-smi -i "${first_card_pci_slot}" -mig 0
 
 echo "==> Cleaning up"
 lxc delete nvidia-mig1 nvidia-mig2 nvidia-mig3 nvidia-mig4

--- a/tests/gpu-mig
+++ b/tests/gpu-mig
@@ -55,13 +55,16 @@ UUID3="$(echo "$UUIDS" | sed -n '3p')"
 UUID4="$(echo "$UUIDS" | sed -n '4p')"
 
 # Launch test containers
-lxc init "${IMAGE}" nvidia-mig1 -c nvidia.runtime=true
+for i in $(seq 1 4); do
+  lxc init "${IMAGE}" "nvidia-mig${i}"
+  if ! hasNeededAPIExtension "gpu_mig_cdi"; then
+    lxc config set "nvidia-mig${i}" nvidia.runtime=true
+  fi
+done
+
 lxc config device add nvidia-mig1 gpu0 gpu gputype=mig mig.uuid="$UUID1" pci="${first_card_pci_slot}"
-lxc init "${IMAGE}" nvidia-mig2 -c nvidia.runtime=true
 lxc config device add nvidia-mig2 gpu0 gpu gputype=mig mig.uuid="$UUID2" pci="${first_card_pci_slot}"
-lxc init "${IMAGE}" nvidia-mig3 -c nvidia.runtime=true
 lxc config device add nvidia-mig3 gpu0 gpu gputype=mig mig.uuid="$UUID3" pci="${first_card_pci_slot}"
-lxc init "${IMAGE}" nvidia-mig4 -c nvidia.runtime=true
 lxc config device add nvidia-mig4 gpu0 gpu gputype=mig mig.uuid="$UUID4" pci="${first_card_pci_slot}"
 lxc start nvidia-mig1
 lxc exec nvidia-mig1 -- nvidia-smi


### PR DESCRIPTION
This PR updates the `gpu-mig` test to account for the new `gpu_mig_cdi` API extension, which makes MIG devices attached to containers use the CDI passthrough instead of the legacy `nvidia.runtime`.

This should be merged together with https://github.com/canonical/lxd/pull/18420.