### PR TITLE
github: Add MIG passthrough test job

### DIFF
--- a/.github/workflows/gpu-passthrough-tests.yml
+++ b/.github/workflows/gpu-passthrough-tests.yml
@@ -111,6 +111,39 @@ jobs:
           client-id: ${{ secrets.TESTFLINGER_CLIENT_ID }}
           secret-key: ${{ secrets.TESTFLINGER_SECRET_KEY }}
 
+  nvidia-mig:
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    strategy:
+      matrix:
+        track: ${{ fromJSON(inputs.snap-track || '["latest/edge"]') }}
+        os: ${{ fromJSON(inputs.ubuntu-releases || '["noble"]') }}
+    env:
+      SNAP_CHANNEL: ${{ matrix.track }}
+      TFWORKFLOW: nvidia-mig-job
+    steps:
+      - name: Event data
+        run: "echo ::notice::Snap channel: $SNAP_CHANNEL"
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Create Testflinger job
+        env:
+          JOB_QUEUE: lxd-mig
+          DISTRO: ${{ matrix.os }}
+        working-directory: ${{ env.TESTFLINGER_DIR }}
+        run: ./run.sh --dryrun
+
+      - name: Run tests
+        uses: canonical/testflinger/.github/actions/submit@545ed69f17a5e639a2299e325f5fb199ca9f98af
+        with:
+          poll: true
+          job-path: ${{ env.TESTFLINGER_DIR }}/${{ env.TFWORKFLOW }}.yml.tmp
+          client-id: ${{ secrets.TESTFLINGER_CLIENT_ID }}
+          secret-key: ${{ secrets.TESTFLINGER_SECRET_KEY }}
+
   amd-cdi:
     runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
     strategy:

--- a/.github/workflows/testflinger/README.md
+++ b/.github/workflows/testflinger/README.md
@@ -13,6 +13,7 @@ Tested distros:
 
 Current queue/workflow combinations:
 - NVIDIA (CDI and legacy runtime): `JOB_QUEUE=lxd-nvidia`, `TFWORKFLOW=nvidia-gpu-job`
+- NVIDIA MIG (Multi-Instance GPU): `JOB_QUEUE=lxd-mig`, `TFWORKFLOW=nvidia-mig-job`
 - Ubuntu Core + NVIDIA CDI: `JOB_QUEUE=lxd-nvidia`, `TFWORKFLOW=uc-nvidia-cdi-job`
 - AMD CDI: `JOB_QUEUE=lxd-amd`, `TFWORKFLOW=amd-cdi-job`
 
@@ -46,4 +47,9 @@ JOB_QUEUE=lxd-nvidia SNAP_CHANNEL=latest/edge DISTRO=noble TFWORKFLOW=nvidia-gpu
 To test Ubuntu Noble + LXD + AMD GPU passthrough in CDI mode:
 ```bash
 JOB_QUEUE=lxd-amd SNAP_CHANNEL=latest/edge DISTRO=noble TFWORKFLOW=amd-cdi-job ./run.sh
+```
+
+To test Ubuntu Noble + LXD + NVIDIA MIG (Multi-Instance GPU) passthrough:
+```bash
+JOB_QUEUE=lxd-mig SNAP_CHANNEL=latest/edge DISTRO=noble TFWORKFLOW=nvidia-mig-job ./run.sh
 ```

--- a/.github/workflows/testflinger/nvidia-mig-job.yml
+++ b/.github/workflows/testflinger/nvidia-mig-job.yml
@@ -1,0 +1,93 @@
+job_queue: $JOB_QUEUE
+global_timeout: 3600
+output_timeout: 1800
+provision_data:
+  distro: $DISTRO
+
+test_data:
+  test_cmds: |
+    #!/bin/bash
+
+    set -xeuo pipefail
+
+    # This is used, along with DEVICE_IP, by all scriptlets to access the device
+    export DEVICE_USER="ubuntu"
+
+    # retrieve the tools installer
+    curl -Ls -o install_tools.sh https://raw.githubusercontent.com/canonical/hwcert-jenkins-tools/main/install_tools.sh
+
+    # install the scriptlets and other tools on the agent and the device, as necessary
+    export TOOLS_PATH=tools
+    source install_tools.sh $TOOLS_PATH
+
+    # ensure device is available before continuing
+    wait-for-ssh --allow-degraded
+
+    # Wait for snapd to become available
+    _run_retry "timeout 5 sudo snap wait system seed.loaded"
+    wait-for-snap-changes
+
+    _run sudo snap remove lxd --purge || true
+
+    GRUB_FILE="/etc/default/grub"
+    NOUVEAU_BLACKLIST="module_blacklist=nouveau"
+
+    if [ -f "/etc/default/grub.d/50-cloudimg-settings.cfg" ]; then
+      GRUB_FILE="/etc/default/grub.d/50-cloudimg-settings.cfg"
+    fi
+
+    # Idempotent command to blacklist nouveau module from loading:
+    if ! grep -q "${NOUVEAU_BLACKLIST}" "${GRUB_FILE}"; then
+      _run sudo sed -i.bak "'s|^\(GRUB_CMDLINE_LINUX_DEFAULT=\"[^\"]*\)\"$|\1 ${NOUVEAU_BLACKLIST}\"|'" "${GRUB_FILE}"
+    fi
+
+    # Apply the changes to the bootloader
+    _run sudo update-grub
+
+    # Find the recommended NVIDIA server-open version
+    _run install_packages ubuntu-drivers-common
+    NVIDIA_DRIVER="$(_run ubuntu-drivers --gpgpu devices | awk '/-server-open/ {print $3}' | sort -V -r | head -n1)"
+    NVIDIA_DRIVER_VERSION="$(echo "${NVIDIA_DRIVER}" | sed 's/.*-\([0-9]\+\)-server-open$/\1/')"
+
+    # install NVIDIA drivers and user space utilities
+    _run sudo ubuntu-drivers install --gpgpu nvidia:${NVIDIA_DRIVER_VERSION}-server-open
+
+    # Let's try to be as close as we can to Ubuntu Core's
+    # mesa-2404:kernel-gpu-2404 components in terms of which packages
+    # we want to have. We need this because it allows us to expect
+    # the same libraries, configuration files, etc available in the container
+    # independently if it's a classic Ubuntu or Ubuntu Core installation.
+    # Please, refer to
+    # https://git.launchpad.net/~canonical-kernel-snaps/canonical-kernel-snaps/+git/kernel-snaps-u24.04/tree/snapcraft.yaml?h=pc-components#n162
+    _run install_packages libnvidia-egl-wayland1 \
+                          libnvidia-cfg1-${NVIDIA_DRIVER_VERSION}-server \
+                          libnvidia-common-${NVIDIA_DRIVER_VERSION}-server \
+                          libnvidia-compute-${NVIDIA_DRIVER_VERSION}-server \
+                          libnvidia-decode-${NVIDIA_DRIVER_VERSION}-server \
+                          libnvidia-encode-${NVIDIA_DRIVER_VERSION}-server \
+                          libnvidia-extra-${NVIDIA_DRIVER_VERSION}-server \
+                          libnvidia-gl-${NVIDIA_DRIVER_VERSION}-server \
+                          libnvidia-fbc1-${NVIDIA_DRIVER_VERSION}-server \
+                          nvidia-utils-${NVIDIA_DRIVER_VERSION}-server
+
+    # reboot and wait for machine to get back
+    _run sudo reboot
+    wait-for-ssh --allow-degraded
+
+    # Show kernel boot arguments for debugging
+    _run cat /proc/cmdline
+
+    # verify that our drivers and tools work properly
+    _run lspci -k
+    _run ls /dev/nvidia*
+    _run nvidia-smi
+
+    # Enable MIG mode.
+    _run sudo nvidia-smi -mig 1
+
+    # Reboot and wait for machine to get back. This is needed because some machines require reboot after enabling MIG mode.
+    _run sudo reboot
+    wait-for-ssh --allow-degraded
+
+    _run git clone --depth=1 --branch main https://github.com/canonical/lxd-ci.git
+    _run "cd lxd-ci && sudo ./bin/local-run tests/gpu-mig $SNAP_CHANNEL < /dev/null"

--- a/tests/gpu-mig
+++ b/tests/gpu-mig
@@ -43,9 +43,25 @@ nvidia-smi mig -i "${first_card_pci_slot}" -lgip
 nvidia-smi mig -i "${first_card_pci_slot}" -cgi 2g.10gb,1g.5gb,1g.5gb
 nvidia-smi mig -i "${first_card_pci_slot}" -lgi
 nvidia-smi mig -i "${first_card_pci_slot}" -lcip
-nvidia-smi mig -i "${first_card_pci_slot}" -cci 1g.5gb -gi 7
-nvidia-smi mig -i "${first_card_pci_slot}" -cci 1g.5gb -gi 13
-nvidia-smi mig -i "${first_card_pci_slot}" -cci 1c.2g.10gb,1c.2g.10gb -gi 5
+
+# GPU instance IDs are assigned by the driver and differ between GPU models, so
+# read back the IDs actually created above instead of hardcoding them. The -lgi
+# table lists one row per instance as "| GPU MIG <profile> <profileID> <instID> <placement> |",
+# so the instance ID is field 6.
+mapfile -t GI_1G5GB < <(nvidia-smi mig -i "${first_card_pci_slot}" -lgi | awk '$3 == "MIG" && $4 == "1g.5gb" {print $6}')
+mapfile -t GI_2G10GB < <(nvidia-smi mig -i "${first_card_pci_slot}" -lgi | awk '$3 == "MIG" && $4 == "2g.10gb" {print $6}')
+
+# The -cgi call above created two 1g.5gb and one 2g.10gb GPU instances. Fail early
+# with a clear message if they weren't found (e.g. MIG mode not actually enabled or
+# an unexpected -lgi output format) instead of a cryptic set -u "unbound variable".
+if [ "${#GI_1G5GB[@]}" -lt 2 ] || [ "${#GI_2G10GB[@]}" -lt 1 ]; then
+  echo "ERROR: expected two 1g.5gb and one 2g.10gb GPU instances, got ${#GI_1G5GB[@]} and ${#GI_2G10GB[@]}" >&2
+  exit 1
+fi
+
+nvidia-smi mig -i "${first_card_pci_slot}" -cci 1g.5gb -gi "${GI_1G5GB[0]}"
+nvidia-smi mig -i "${first_card_pci_slot}" -cci 1g.5gb -gi "${GI_1G5GB[1]}"
+nvidia-smi mig -i "${first_card_pci_slot}" -cci 1c.2g.10gb,1c.2g.10gb -gi "${GI_2G10GB[0]}"
 nvidia-smi
 
 UUIDS="$(nvidia-smi -L | sed -n "/(UUID: MIG-/ s/.* \(MIG-[^)]\+\))$/\1/p")"


### PR DESCRIPTION
This PR adds a dedicated job `nvidia-mig` to the `GPU Passthrough` workflow for testing Nvidia MIG GPU passthrough to LXD containers.

The new `nvidia-mig` job uses the existing `tests/gpu-mig` test.

The PR also extends the `tests/gpu-mig` to correctly select MIG GPU instance IDs for the test instead of using hardcoded values that only work on specific machines.