### PR TITLE
6.17 kernels now have the fix for LP: #2147374

### DIFF
--- a/bin/helpers
+++ b/bin/helpers
@@ -459,7 +459,7 @@ coverage_enabled() {
 # Setup instance to collect coverage data from running Go binaries from inside the instance.
 # If coverage is not enabled, this is a no-op.
 # If the instance is a VM, the lxd-agent will be instrumented too.
-# Note: incompatible with `migration.stateful=true` instances.
+# Note: incompatible with `migration.stateful=true` instances due to relying on host shared directory for coverage data.
 setup_instance_gocoverage() {
   coverage_enabled || return 0
 

--- a/tests/storage-metadata
+++ b/tests/storage-metadata
@@ -1,25 +1,6 @@
 #!/bin/bash
 set -eux
 
-# XXX: avoid known issue: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2147374
-# VM inside container causes a kernel NULL pointer dereference on 6.17; fixed in -generic >= 6.17.0-29
-# and -azure >= 6.17.0-1015. Skip on all other 6.17 kernels until the issue is fixed.
-_kernel="$(uname -r)"
-if [[ "${_kernel}" =~ ^6\.17\.0 ]]; then
-  _skip=1
-  if [[ "${_kernel}" =~ ^6\.17\.0-([0-9]+)-generic$ ]] && [ "${BASH_REMATCH[1]}" -ge 29 ]; then
-    _skip=0
-  elif [[ "${_kernel}" =~ ^6\.17\.0-([0-9]+)-azure ]] && [ "${BASH_REMATCH[1]}" -ge 1015 ]; then
-    _skip=0
-  fi
-  if [ "${_skip}" = "1" ]; then
-    echo "Skipping storage-metadata tests on kernel ${_kernel} that has a known issue (LP: #2147374)"
-    # shellcheck disable=SC2034
-    FAIL=0
-    exit 0
-  fi
-fi
-
 # Checks the given backup file contents for format version 1.
 check_format_version1() {
     backupFile="$1"

--- a/tests/vm-nesting
+++ b/tests/vm-nesting
@@ -27,23 +27,6 @@ if echo "${LXD_SNAP_CHANNEL}" | grep -qE "^4\.0/"; then
     fi
 fi
 
-# XXX: workaround for https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2147374
-# VM inside container causes a kernel NULL pointer dereference on 6.17; fixed in -generic >= 6.17.0-29
-# and -azure >= 6.17.0-1015. Skip on all other 6.17 kernels until the issue is fixed.
-_kernel="$(uname -r)"
-if [[ "${_kernel}" =~ ^6\.17\.0 ]]; then
-	_skip=1
-	if [[ "${_kernel}" =~ ^6\.17\.0-([0-9]+)-generic$ ]] && [ "${BASH_REMATCH[1]}" -ge 29 ]; then
-		_skip=0
-	elif [[ "${_kernel}" =~ ^6\.17\.0-([0-9]+)-azure ]] && [ "${BASH_REMATCH[1]}" -ge 1015 ]; then
-		_skip=0
-	fi
-	if [ "${_skip}" = "1" ]; then
-		echo "::warning:: Skipping VM in container tests on kernel ${_kernel} due to a known issue (LP: #2147374)"
-		VM_IN_CTN=0
-	fi
-fi
-
 # Configure LXD.
 lxc project switch default
 lxc storage create default "${storageDriver}" size=30GiB


### PR DESCRIPTION
Also add a note  explaining why `setup_instance_gocoverage` doesn't work with `migration.stateful=true`