### PR TITLE
Revert "bin/local-run: reload global env after cloud-init"

### DIFF
--- a/bin/local-run
+++ b/bin/local-run
@@ -6,10 +6,6 @@ set -o pipefail
 if command -v cloud-init > /dev/null; then
     echo "Waiting for cloud-init"
     cloud-init status --wait --long
-
-    # cloud-init might put environment variables which we'd miss if we 'lxc shell'ed in too early
-    . /etc/environment
-
     echo "Done"
 fi
 


### PR DESCRIPTION
Sourcing `/etc/environment` as the unintended side effect of resetting the `PATH` to the normal value. This works against us when in the LXD repo, a dir full of coverage enabled binaries is added to the `PATH` to collect code coverage results.

This reverts commit 920c0ab048e2154e28f750608e374945004d64f7.