### PR TITLE
tests: Add 4.0 to known tracks list

### DIFF
--- a/tests/cluster
+++ b/tests/cluster
@@ -2,7 +2,7 @@
 set -eux
 
 # Known LXD snap tracks in ascending order. Update when a new track is opened.
-KNOWN_TRACKS=("5.0" "5.21" "6")
+KNOWN_TRACKS=("4.0" "5.0" "5.21" "6")
 
 # get_upgrade_chain returns the ordered list of channels to upgrade through.
 # The first element is the source (install) channel.


### PR DESCRIPTION
From what I can tell this should allow the `get_upgrade_chain` function to return a bash array containing the following upgrade chain:
- `4.0/candidate`
- `5.0/candidate`
- `5.21/candidate`
- `6/stable`

Where 4.0, 5.0, and 5.21 are using candidate due to a dqlite issue