### PR TITLE
bin/local-run: only wait for cloud-init in VMs

### DIFF
--- a/bin/local-run
+++ b/bin/local-run
@@ -2,8 +2,8 @@
 set -eux
 set -o pipefail
 
-# wait for cloud-init to be done setting up the local env
-if command -v cloud-init > /dev/null; then
+# wait for cloud-init to be done setting up the local VM env
+if command -v cloud-init > /dev/null && systemd-detect-virt --quiet --vm; then
     echo "Waiting for cloud-init"
     cloud-init status --wait --long
     echo "Done"


### PR DESCRIPTION
Some Testflinger machines are unable to get a successful `cloud-init status --wait` which prevents them reusing those CI tests.

This wait was added to ensure a local test VM using the `lxd-ci` profile was fully ready before launching the test script.

By waiting only when a VM is detected, both should be happy.