### PR TITLE
tests/snapd: verify the `lxc help` warmup produced valid output

### DIFF
--- a/tests/snapd
+++ b/tests/snapd
@@ -5,10 +5,16 @@ set -eux
 install_lxd false
 
 test_lxc() {
+    local DURATION OUT
     DURATION="${1}"
 
     echo "Warmup"
-    lxc help >/dev/null
+    OUT="$(lxc help)"
+    if ! grep -xF "Description:" <<<"${OUT}"; then
+        echo "Unexpected lxc help output:" >&2
+        echo "${OUT}" >&2
+        exit 1
+    fi
 
     echo "Repeatedly call 'lxc help' for ${DURATION} and see how fast/slow it is"
     # shellcheck disable=SC2016


### PR DESCRIPTION
This should help understand failures that present like [this](https://github.com/canonical/lxd/actions/runs/28800642347/job/85404455280#step:22:177):
```
+ test_lxc 30
Warmup
+ DURATION=30
+ echo Warmup
+ lxc help
+ echo 'Repeatedly call '\''lxc help'\'' for 30 and see how fast/slow it is'
Repeatedly call 'lxc help' for 30 and see how fast/slow it is
++ timeout 30 bash -c 'i=0; trap "echo \$i" EXIT; while i=$((i+1)); do lxc help >/dev/null; done'
++ true
+ ITERATIONS=
+ '[' '' -ge 0 ']'
/tmp/snapd.WXIm: line 746: [: : integer expression expected
+ cleanup
```