### PR TITLE
Configure `lvm.external` early

### DIFF
--- a/tests/conversion
+++ b/tests/conversion
@@ -297,16 +297,7 @@ IMAGE_PATH="${tmpdir}/backup/virtual-machine.img"
 # Test VM migration using conversion mode. If server does not support
 # conversion API extension, the conversion tool must fallback to migration
 # mode and successfully transfer the VM disk.
-# Note: testing lvm first as it often fails
-for driver in lvm btrfs ceph dir zfs; do
-    if [ "${driver}" = "lvm" ]; then
-        # For LVM thin use external LVM tools to avoid errors like:
-        # Failed to run: lvcreate --yes --wipesignatures y --thinpool --extents 100%FREE: Device or resource busy
-        snap set lxd lvm.external=true
-        systemctl reload snap.lxd.daemon.service
-        lxd waitready --timeout=300
-    fi
-
+for driver in btrfs ceph dir lvm zfs; do
     conversion_vm alpine-raw "${driver}" "${IMAGE_PATH}" "no"
 done
 

--- a/tests/conversion
+++ b/tests/conversion
@@ -21,6 +21,12 @@ install_lxd
 
 set -x
 
+# For LVM thin use external LVM tools to avoid errors like:
+# Failed to run: lvcreate --yes --wipesignatures y --thinpool --extents 100%FREE: Device or resource busy
+snap set lxd lvm.external=true
+systemctl reload snap.lxd.daemon.service
+lxd waitready --timeout=300
+
 if ! command -v go; then
     # Install go from Snap.
     waitSnapdSeed

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -13,6 +13,14 @@ IMAGE="${TEST_IMG:-ubuntu-minimal-daily:24.04}"
 
 poolDriverList="${1:-ceph dir btrfs lvm lvm-thin zfs}"
 
+if echo "${poolDriverList}" | grep -qwF "lvm-thin"; then
+    # For LVM thin use external LVM tools to avoid errors like:
+    # Failed to run: lvcreate --yes --wipesignatures y --thinpool --extents 100%FREE: Device or resource busy
+    snap set lxd lvm.external=true
+    systemctl reload snap.lxd.daemon.service
+    lxd waitready --timeout=300
+fi
+
 # Configure LXD
 lxc network create lxdbr0
 lxc profile device add default eth0 nic network=lxdbr0
@@ -69,11 +77,6 @@ for poolDriver in $poolDriverList; do
                 ! lxc storage set "${poolName}" size=58GiB || false
                 [ "$(lxc storage get "${poolName}" size)" = "60GiB" ]
         elif [ "${poolDriver}" = "lvm-thin" ]; then
-                # For LVM thin use external LVM tools to avoid errors like:
-                # Failed to run: lvcreate --yes --wipesignatures y --thinpool --extents 100%FREE: Device or resource busy
-                snap set lxd lvm.external=true
-                systemctl reload snap.lxd.daemon.service
-                lxd waitready --timeout=300
                 lxc storage create "${poolName}" lvm size=19GiB
                 lxc storage set "${poolName}" size=20GiB
                 ! lxc storage set "${poolName}" size=18GiB || false


### PR DESCRIPTION
There is a known race in:

```
systemctl reload snap.lxd.daemon.service
lxd waitready --timeout=300
```

Where the LXD daemon might still be going down by the time the `reload` command returns. This causes `lxd waitready` to start monitoring a shutting down daemon which leads to an error:

```
+ for driver in lvm btrfs ceph dir zfs
+ '[' lvm = lvm ']'
+ snap set lxd lvm.external=true
+ systemctl reload snap.lxd.daemon.service
+ lxd waitready --timeout=300
Error: LXD daemon is shutting down after 300s timeout
```