### PR TITLE
Only reload if the daemon is active

### DIFF
--- a/tests/conversion
+++ b/tests/conversion
@@ -24,7 +24,9 @@ set -x
 # For LVM thin use external LVM tools to avoid errors like:
 # Failed to run: lvcreate --yes --wipesignatures y --thinpool --extents 100%FREE: Device or resource busy
 snap set lxd lvm.external=true
-systemctl reload snap.lxd.daemon.service
+if systemctl is-active --quiet snap.lxd.daemon.service; then
+    systemctl reload snap.lxd.daemon.service
+fi
 lxd waitready --timeout=300
 
 if ! command -v go; then

--- a/tests/storage-vm
+++ b/tests/storage-vm
@@ -17,7 +17,9 @@ if echo "${poolDriverList}" | grep -qwF "lvm-thin"; then
     # For LVM thin use external LVM tools to avoid errors like:
     # Failed to run: lvcreate --yes --wipesignatures y --thinpool --extents 100%FREE: Device or resource busy
     snap set lxd lvm.external=true
-    systemctl reload snap.lxd.daemon.service
+    if systemctl is-active --quiet snap.lxd.daemon.service; then
+        systemctl reload snap.lxd.daemon.service
+    fi
     lxd waitready --timeout=300
 fi
 


### PR DESCRIPTION
Works around:
```
+ snap set lxd lvm.external=true
+ systemctl reload snap.lxd.daemon.service
snap.lxd.daemon.service is not active, cannot reload.
```

This regression was introduced by https://github.com/canonical/lxd-ci/pull/816