### PR TITLE
tests/gpu-container: Use API extension guard for GPU hotplug

### DIFF
--- a/tests/gpu-container
+++ b/tests/gpu-container
@@ -177,16 +177,19 @@ if hasNeededAPIExtension "gpu_cdi"; then
     lxc exec c1 -- sh -c 'ls /dev/dri/renderD[0-9]*'
     lxc exec c1 -- nvidia-smi
 
-    echo "==> Testing hotplugging a GPU into a running container"
-    lxc config device remove c1 gpu0
-    sleep 1
-    [ "$(count_gpu_devices c1)" = "0" ]
-    lxc config device add c1 gpu0 gpu id="nvidia.com/gpu=0"
-    sleep 1
-    [ "$(count_gpu_devices c1)" = "1" ]
-    check_ldconfig c1
-    check_mountinfo c1
-    lxc exec c1 -- nvidia-smi
+    # Test hotplugging if supported.
+    if hasNeededAPIExtension "gpu_cdi_hotplug"; then
+        echo "==> Testing hotplugging a GPU into a running container"
+        lxc config device remove c1 gpu0
+        sleep 1
+        [ "$(count_gpu_devices c1)" = "0" ]
+        lxc config device add c1 gpu0 gpu id="nvidia.com/gpu=0"
+        sleep 1
+        [ "$(count_gpu_devices c1)" = "1" ]
+        check_ldconfig c1
+        check_mountinfo c1
+        lxc exec c1 -- nvidia-smi
+    fi
 
     echo "==> Testing running nested Docker container with nvidia runtime"
 


### PR DESCRIPTION
Follow-up to https://github.com/canonical/lxd-ci/pull/803.