### PR TITLE
test/devlxd-vm: Wait instance booted before installing curl

### DIFF
--- a/tests/devlxd-vm
+++ b/tests/devlxd-vm
@@ -26,7 +26,7 @@ else
   lxc launch "${IMAGE}" v1 --vm -s "${poolName}"
 fi
 
-waitInstanceReady v1
+waitInstanceBooted v1
 setup_instance_gocoverage v1
 lxc info v1
 


### PR DESCRIPTION
Network needs to be ready before we install curl now its not bundled.