### PR TITLE
tests/snapd: force string parsing for lxd `daemon.preseed`

### DIFF
--- a/tests/snapd
+++ b/tests/snapd
@@ -37,7 +37,7 @@ test_lxc() {
 test_lxc
 
 # Set preseed via snap
-snap set lxd daemon.preseed='{"config": {"core.https_address": "[::]:8443"}}'
+snap set -s lxd daemon.preseed='{"config": {"core.https_address": "[::]:8443"}}'
 
 lxd waitready --timeout=300
 


### PR DESCRIPTION
`snapd` recently started attempting to parse raw JSON payloads in `snap set` as nested option keys, causing validation errors for keys containing dots or underscores (such as "core.https_address"). Pass `-s` to `snap set` so the preseed is treated as a raw string.