### PR TITLE
Use smaller/newer Canonical runners for TF job schedulers

### DIFF
--- a/.github/workflows/gpu-passthrough-tests.yml
+++ b/.github/workflows/gpu-passthrough-tests.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   uc-nvidia-cdi:
-    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-small]
     strategy:
       matrix:
         track: ${{ fromJSON(inputs.snap-track || '["latest/edge"]') }}
@@ -79,7 +79,7 @@ jobs:
           secret-key: ${{ secrets.TESTFLINGER_SECRET_KEY }}
 
   nvidia:
-    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-small]
     strategy:
       matrix:
         track: ${{ fromJSON(inputs.snap-track || '["latest/edge"]') }}
@@ -112,7 +112,7 @@ jobs:
           secret-key: ${{ secrets.TESTFLINGER_SECRET_KEY }}
 
   nvidia-mig:
-    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-small]
     strategy:
       matrix:
         track: ${{ fromJSON(inputs.snap-track || '["latest/edge"]') }}
@@ -145,7 +145,7 @@ jobs:
           secret-key: ${{ secrets.TESTFLINGER_SECRET_KEY }}
 
   amd-cdi:
-    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-small]
     strategy:
       matrix:
         track: ${{ fromJSON(inputs.snap-track || '["latest/edge"]') }}

--- a/bin/testflinger-run
+++ b/bin/testflinger-run
@@ -79,8 +79,8 @@ EOF
 
 setup_testflinger() {
     # Test connectivity
-    if ! wget --method HEAD -qO /dev/null https://testflinger.canonical.com/agents; then
-        echo "Failed to connect to testflinger.canonical.com, make sure you are connected to the VPN" >&2
+    if ! wget --method HEAD -qO /dev/null https://testflinger.canonical.com/; then
+        echo "Failed to connect to testflinger.canonical.com" >&2
         exit 1
     fi
 


### PR DESCRIPTION
Now that the VPN is no longer required to access TF, I initially intended to switch to `ubuntu-slim` GitHub-hosted runners. However, since those come with a hard execution limit of 15 minutes before the job is cancelled/failed they wouldn't work.

https://documentation.ubuntu.com/self-hosted-runners/en/latest/usage/available_runners/ showed that `medium` runners were needlessly powerful for a mere scheduler instances so I switched to a `small` ones. I also replaced `jammy` by `noble`.