### PR TITLE
tests: Add snapcraft integration test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,6 +132,7 @@ jobs:
           - network-routed
           - pylxd
           - qemu-external-vm
+          - snapcraft
           - snapd
           - storage-buckets
           - storage-disks-vm
@@ -193,6 +194,8 @@ jobs:
             track: "4.0/candidate"
           - test: qemu-external-vm
             track: "4.0/candidate"
+          - test: snapcraft
+            track: "4.0/candidate"
           - test: storage-buckets
             track: "4.0/candidate"
           - test: storage-disks-vm
@@ -243,6 +246,8 @@ jobs:
             track: "4.0/edge"
           - test: qemu-external-vm
             track: "4.0/edge"
+          - test: snapcraft
+            track: "4.0/edge"
           - test: storage-buckets
             track: "4.0/edge"
           - test: storage-disks-vm
@@ -292,6 +297,10 @@ jobs:
             track: "5.0/candidate"
           - test: qemu-external-vm
             track: "5.0/edge"
+          - test: snapcraft
+            track: "5.0/candidate"
+          - test: snapcraft
+            track: "5.0/edge"
           - test: vm-migration
             track: "5.0/candidate"
           - test: vm-migration
@@ -309,11 +318,19 @@ jobs:
             track: "5.21/candidate"
           - test: qemu-external-vm
             track: "5.21/edge"
+          - test: snapcraft
+            track: "5.21/stable"
+          - test: snapcraft
+            track: "5.21/candidate"
+          - test: snapcraft
+            track: "5.21/edge"
           # some tests are not worth testing on specific OSes
           - os: 22.04
             test: lxd-installer
           - os: 22.04
             test: qemu-external-vm
+          - os: 22.04
+            test: snapcraft
           # skip track/os combinations that are too far appart
           - os: 24.04
             track: "4.0/candidate"

--- a/tests/snapcraft
+++ b/tests/snapcraft
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eux
+
+# Install and setup LXD.
+install_lxd
+lxd init --auto
+
+# Install snapcraft (use latest/candidate to help catch regressions in LXD/snapcraft earlier).
+snap install snapcraft --classic --channel=latest/candidate
+
+tmpdir="$(mktemp -d)"
+cd "${tmpdir}"
+
+mkdir -p "${tmpdir}/snap"
+mkdir -p "${tmpdir}/src"
+
+# Create the app to pack.
+cat << 'EOF' > "${tmpdir}/src/example.sh"
+#!/bin/bash
+echo "Example snap."
+EOF
+
+chmod +x "${tmpdir}/src/example.sh"
+
+# Create the snapcraft.yaml file.
+cat << 'EOF' > "${tmpdir}/snap/snapcraft.yaml"
+name: snap-example
+version: '0.1'
+summary: A simple snap
+description: |
+  This is a basic snap.
+
+base: core24
+confinement: strict
+grade: devel
+
+apps:
+  snap-example:
+    command: bin/example.sh
+
+parts:
+  example-script:
+    plugin: dump
+    source: src/
+    organize:
+      example.sh: bin/example.sh
+EOF
+
+# Produce the snap file.
+snapcraft pack -v
+
+# Verify the snap artifact was produced (arch suffix varies, so glob it).
+ls snap-example_0.1_*.snap
+
+# Confirm snapcraft used the LXD backend.
+lxc list --project snapcraft
+
+# Clean up the temporary working directory.
+cd - > /dev/null
+rm -rf "${tmpdir}"
+
+# shellcheck disable=SC2034
+FAIL=0


### PR DESCRIPTION
This PR adds a dedicated test for verifying that LXD and Snapcraft work correctly together.

This is helpful for making sure that the incoming image registries LXD feature does not break anything for Snapcraft.