### PR TITLE
github: Add 5.0 snap track for GPU passthrough tests

### DIFF
--- a/.github/workflows/gpu-passthrough-tests.yml
+++ b/.github/workflows/gpu-passthrough-tests.yml
@@ -49,6 +49,8 @@ env:
 jobs:
   uc-nvidia-cdi:
     runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-small]
+    # LXD 5.0 does not support CDI, only `nvidia.runtime`.
+    if: ${{ !contains(inputs.snap-track, '5.0/') }}
     strategy:
       matrix:
         track: ${{ fromJSON(inputs.snap-track || '["latest/edge"]') }}
@@ -149,6 +151,8 @@ jobs:
 
   amd-cdi:
     runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-small]
+    # AMD CDI is not supported on LXD 5.0.
+    if: ${{ !contains(inputs.snap-track, '5.0/') }}
     strategy:
       matrix:
         track: ${{ fromJSON(inputs.snap-track || '["latest/edge"]') }}

--- a/.github/workflows/gpu-passthrough-tests.yml
+++ b/.github/workflows/gpu-passthrough-tests.yml
@@ -31,6 +31,9 @@ on:
           - '["5.21/edge"]'
           - '["5.21/candidate"]'
           - '["5.21/stable"]'
+          - '["5.0/edge"]'
+          - '["5.0/candidate"]'
+          - '["5.0/stable"]'
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR adds LXD `5.0` snap track for GPU passthrough tests.