### PR TITLE
github: Improve GPU passthrough test matrix

### DIFF
--- a/.github/workflows/gpu-passthrough-tests.yml
+++ b/.github/workflows/gpu-passthrough-tests.yml
@@ -49,11 +49,14 @@ env:
 jobs:
   uc-nvidia-cdi:
     runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-small]
-    # LXD 5.0 does not support CDI, only `nvidia.runtime`.
-    if: ${{ !contains(inputs.snap-track, '5.0/') }}
     strategy:
       matrix:
         track: ${{ fromJSON(inputs.snap-track || '["latest/edge"]') }}
+        # LXD 5.0 does not support CDI, only `nvidia.runtime`.
+        exclude:
+          - track: '5.0/edge'
+          - track: '5.0/candidate'
+          - track: '5.0/stable'
     env:
       SNAP_CHANNEL: ${{ matrix.track }}
       TFWORKFLOW: uc-nvidia-cdi-job
@@ -151,12 +154,18 @@ jobs:
 
   amd-cdi:
     runs-on: [self-hosted, self-hosted-linux-amd64-noble-private-endpoint-small]
-    # AMD CDI is not supported on LXD 5.0.
-    if: ${{ !contains(inputs.snap-track, '5.0/') }}
     strategy:
       matrix:
         track: ${{ fromJSON(inputs.snap-track || '["latest/edge"]') }}
         os: ${{ fromJSON(inputs.ubuntu-releases || '["noble"]') }}
+        # AMD CDI is not supported on LXD 5.0 or 5.21.
+        exclude:
+          - track: '5.0/edge'
+          - track: '5.0/candidate'
+          - track: '5.0/stable'
+          - track: '5.21/edge'
+          - track: '5.21/candidate'
+          - track: '5.21/stable'
     env:
       SNAP_CHANNEL: ${{ matrix.track }}
       TFWORKFLOW: amd-cdi-job


### PR DESCRIPTION
This PR excludes AMD tests from 5.21 LXD series.

It also fixes previous AMD and CDI jobs exclusions using the `matrix.exclude`, so that these jobs are only skipped where necessary when using multi-track dispatch.