### PR TITLE
LXD-4910(tests): New snap-shutdown-order test to validate systemd shutdown ordering

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,6 +131,7 @@ jobs:
           - network-routed
           - pylxd
           - qemu-external-vm
+          - snap-shutdown-order
           - snapcraft
           - snapd
           - storage-buckets
@@ -150,6 +151,20 @@ jobs:
           - vm-migration
           - vm-nesting
         exclude:
+          - test: snap-shutdown-order
+            track: "4.0/candidate"
+          - test: snap-shutdown-order
+            track: "4.0/edge"
+          - test: snap-shutdown-order
+            track: "5.0/candidate"
+          - test: snap-shutdown-order
+            track: "5.0/edge"
+          - test: snap-shutdown-order
+            track: "5.21/stable"
+          - test: snap-shutdown-order
+            track: "5.21/candidate"
+          - test: snap-shutdown-order
+            track: "5.21/edge"
           - test: csi
             track: "4.0/candidate"
           - test: csi

--- a/tests/snap-shutdown-order
+++ b/tests/snap-shutdown-order
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -eux
+
+install_microceph
+install_ovn
+install_lxd
+
+microceph status || microceph cluster bootstrap
+# Skip microovn coverage if there are no microovn snap services 
+if [ "${OVN_SOURCE:-latest/edge}" = "deb" ]; then
+    microovn status || microovn cluster bootstrap
+fi
+# Launch an instance to slow down lxc shutdown
+lxd init --auto
+lxc launch "${TEST_IMG:-ubuntu-minimal-daily:24.04}" c1
+
+# Every microceph/microovn unit must appear in LXD's After=
+after="$(systemctl show -p After --value snap.lxd.daemon.service | tr ' ' '\n')"
+for unit in $(systemctl list-units --all --plain --no-legend 'snap.microceph.*.service' 'snap.microovn.*.service' | sed 's/ .*$//'); do
+    grep -qxF "${unit}" <<< "${after}"
+done
+
+# Stop them together and LXD stopped first
+units="$(systemctl list-units --state=active --plain --no-legend 'snap.microceph.*.service' 'snap.microovn.*.service' | sed 's/ .*$//')"
+# shellcheck disable=SC2086
+systemctl stop snap.lxd.daemon.service ${units}
+lxd_stopped="$(systemctl show -p InactiveEnterTimestampMonotonic --value snap.lxd.daemon.service)"
+for unit in ${units}; do
+    unit_stopped="$(systemctl show -p InactiveEnterTimestampMonotonic --value "${unit}")"
+    if [ "${unit_stopped}" -le 0 ]; then
+        echo "ERROR - unit ${unit} not stopped after systemctl stop return"
+        exit 1
+    elif [ "${lxd_stopped}" -gt "${unit_stopped}" ]; then
+        echo "ERROR - LXD stopped after unit ${unit}"
+        exit 1
+    fi
+
+done
+
+# shellcheck disable=SC2034
+FAIL=0


### PR DESCRIPTION
This contains the new snap-shutdown-order test which is enabled only for V6 until backport. The new test verifies that LXD is shut down prior to any microceph/microovn service being shut down.

Depends on: https://github.com/canonical/lxd/pull/18926